### PR TITLE
Define message interpreters

### DIFF
--- a/bin/cm-janus
+++ b/bin/cm-janus
@@ -1,4 +1,6 @@
 #!/bin/env node
+
+process.env['NODE_CONFIG_DIR'] = __dirname + '/config';
 var CMJanus = require('../lib/index.js');
 
 var proxy = new CMJanus.JanusProxy('8188', 'ws://198.23.87.26:8188/janus');

--- a/lib/janus-proxy.js
+++ b/lib/janus-proxy.js
@@ -3,6 +3,7 @@ var Auth = require('./auth');
 var WebSocketServer = require('ws').Server;
 var JanusConnection = require('./janus-connection');
 var Plugin = require('./plugin');
+var Stream = require('./stream');
 var ProxyConnection = require('./proxy-connection');
 
 /**
@@ -48,9 +49,7 @@ JanusProxy.prototype.start = function() {
           plugin.on('message', function(request) {
             var body = request['body'];
             if ('watch' == body['request']) {
-              //var streamId = body['id'];
-              //var streamName = plugin.id;
-              //var stream = new Stream(streamName, proxyConnection.sessionId);
+              var stream = new Stream(body['id'], plugin.id, proxyConnection.sessionId);
               // ? plugin.addStream();
             }
           });

--- a/lib/janus-proxy.js
+++ b/lib/janus-proxy.js
@@ -2,7 +2,6 @@ var logger = require('./logger');
 var Auth = require('./auth');
 var WebSocketServer = require('ws').Server;
 var JanusConnection = require('./janus-connection');
-var Stream = require('./proxy-connection');
 var Plugin = require('./plugin');
 var ProxyConnection = require('./proxy-connection');
 
@@ -27,21 +26,50 @@ JanusProxy.prototype.start = function() {
     var proxyConnection = new ProxyConnection(browserConnection, janusConnection, this.auth);
     proxyConnection.enableProxy();
 
+    proxyConnection.on('create', function(request, response) {
+      proxyConnection.sessionId = response['data']['id'];
+    });
+
     proxyConnection.on('attach', function(request, response) {
-      var plugin = new Plugin(response.data.id, request.plugin);
+      var plugin = new Plugin(response['data']['id'], request['plugin']);
       proxyConnection.attachPlugin(plugin);
 
-      switch (request.plugin) {
+      switch (plugin.name) {
         case 'janus.plugin.streaming':
-          var streamName = plugin.id;
-          var stream = new Stream(streamName, proxyConnection.sessionId);
+
+          plugin.on('message', function(request) {
+            var body = request['body'];
+            if ('watch' == body['request']) {
+              //var streamId = body['id'];
+              //var streamName = plugin.id;
+              //var stream = new Stream(streamName, proxyConnection.sessionId);
+              // ? plugin.addStream();
+            }
+          });
 
           plugin.on('webrtcup', function(request) {
             logger.debug('webrtc is up');
             // send stream to cm-application
           });
+
+          plugin.on('media', function(request, response) {
+            // ?
+          });
+
+          plugin.on('hangup', function(request, response) {
+            // send 'stream stop' to cm-app
+          });
+
+          plugin.on('detach', function() {
+            proxyConnection.detachPlugin(plugin);
+          });
+
           break;
       }
+    });
+
+    proxyConnection.on('destroy', function(request, response) {
+      proxyConnection.sessionId = null;
     });
   }.bind(this));
 };

--- a/lib/janus-proxy.js
+++ b/lib/janus-proxy.js
@@ -27,10 +27,18 @@ JanusProxy.prototype.start = function() {
     proxyConnection.enableProxy();
 
     proxyConnection.on('create', function(request, response) {
+      if ('error' == response['janus']) {
+        // inform cm that session couldn't be created
+        return;
+      }
       proxyConnection.sessionId = response['data']['id'];
     });
 
     proxyConnection.on('attach', function(request, response) {
+      if ('error' == response['janus']) {
+        // inform cm that plugin couldn't be attached
+        return;
+      }
       var plugin = new Plugin(response['data']['id'], request['plugin']);
       proxyConnection.attachPlugin(plugin);
 
@@ -61,6 +69,10 @@ JanusProxy.prototype.start = function() {
           });
 
           plugin.on('detach', function() {
+            if ('error' == response['janus']) {
+              // inform cm that detach failed
+              return;
+            }
             proxyConnection.detachPlugin(plugin);
           });
 
@@ -69,6 +81,10 @@ JanusProxy.prototype.start = function() {
     });
 
     proxyConnection.on('destroy', function(request, response) {
+      if ('error' == response['janus']) {
+        // inform cm that destroy failed
+        return;
+      }
       proxyConnection.sessionId = null;
     });
   }.bind(this));

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,9 +1,9 @@
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
-function Plugin(id, type) {
+function Plugin(id, name) {
   this.id = id;
-  this.type = type;
+  this.name = name;
 }
 
 util.inherits(Plugin, EventEmitter);

--- a/lib/proxy-connection.js
+++ b/lib/proxy-connection.js
@@ -16,7 +16,7 @@ function ProxyConnection(browserConnection, janusConnection, auth) {
   this.auth = auth;
   this.transactions = {};
   this.plugins = {};
-
+  this.sessionId = null;
 }
 
 util.inherits(ProxyConnection, EventEmitter);
@@ -26,7 +26,7 @@ ProxyConnection.prototype.enableProxy = function() {
   self.browserConnection.on('message', function(data) {
     var message = JSON.parse(data);
     logger.debug('to janus: ', message);
-    self.auth.authorizeConnection(self, message.token).then(function() {
+    self.auth.authorizeConnection(self, message['token']).then(function() {
       if (self.auth.isValidConnection(self) && self.isValidMessage(message)) {
         self.handleMessage(message);
         self.janusConnection.send(data);
@@ -61,7 +61,7 @@ ProxyConnection.prototype.enableProxy = function() {
  * @returns {Boolean}
  */
 ProxyConnection.prototype.isValidMessage = function(message) {
-  var pluginId = this._extractPlugin(message);
+  var pluginId = this.extractPluginId(message);
   if (pluginId) {
     return this._isValidMessagePlugin(message, pluginId);
   } else {
@@ -69,7 +69,11 @@ ProxyConnection.prototype.isValidMessage = function(message) {
   }
 };
 
-ProxyConnection.prototype._extractPlugin = function(message) {
+/**
+ * @param {Object} message
+ * @returns {String}
+ */
+ProxyConnection.prototype.extractPluginId = function(message) {
   return message['handle_id'] || message['sender'];
 };
 
@@ -79,7 +83,7 @@ ProxyConnection.prototype._isValidMessagePlugin = function(message, pluginId) {
 
 ProxyConnection.prototype._isValidMessageNoPlugin = function(message) {
   var eventName = message['janus'];
-  var legalEventList = ['create', 'success', 'error', 'attach', 'trickle', 'ack', 'keepalive'];
+  var legalEventList = ['create', 'destroy', 'success', 'error', 'attach', 'trickle', 'ack', 'keepalive'];
   if (!_.contains(legalEventList, eventName)) {
     return false;
   }
@@ -87,6 +91,11 @@ ProxyConnection.prototype._isValidMessageNoPlugin = function(message) {
     var pluginName = message['plugin'];
     var legalPluginList = ['janus.plugin.streaming', 'janus.plugin.audiobridge'];
     if (!_.contains(legalPluginList, pluginName)) {
+      return false;
+    }
+  }
+  if ('destroy' == eventName) {
+    if (this.sessionId != message['session_id']) {
       return false;
     }
   }
@@ -128,7 +137,7 @@ ProxyConnection.prototype.handleMessage = function(message) {
 ProxyConnection.prototype.emitEvent = function(eventName, request, response) {
   logger.debug('event triggered', eventName);
   this.emit(eventName, request, response);
-  var plugin = this.plugins[request.sender] || null;
+  var plugin = this.plugins[this.extractPluginId(request)];
   if (plugin) {
     plugin.emit(eventName, request, response);
   }

--- a/lib/proxy-connection.js
+++ b/lib/proxy-connection.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var logger = require('./logger');
 var WebSocket = require('ws');
 var EventEmitter = require('events').EventEmitter;
@@ -60,7 +61,36 @@ ProxyConnection.prototype.enableProxy = function() {
  * @returns {Boolean}
  */
 ProxyConnection.prototype.isValidMessage = function(message) {
-  return !message.sender || this.plugins[message.sender];
+  var pluginId = this._extractPlugin(message);
+  if (pluginId) {
+    return this._isValidMessagePlugin(message, pluginId);
+  } else {
+    return this._isValidMessageNoPlugin(message);
+  }
+};
+
+ProxyConnection.prototype._extractPlugin = function(message) {
+  return message['handle_id'] || message['sender'];
+};
+
+ProxyConnection.prototype._isValidMessagePlugin = function(message, pluginId) {
+  return !!this.plugins[pluginId];
+};
+
+ProxyConnection.prototype._isValidMessageNoPlugin = function(message) {
+  var eventName = message['janus'];
+  var legalEventList = ['create', 'success', 'error', 'attach', 'trickle', 'ack', 'keepalive'];
+  if (!_.contains(legalEventList, eventName)) {
+    return false;
+  }
+  if ('attach' == eventName) {
+    var pluginName = message['plugin'];
+    var legalPluginList = ['janus.plugin.streaming', 'janus.plugin.audiobridge'];
+    if (!_.contains(legalPluginList, pluginName)) {
+      return false;
+    }
+  }
+  return true;
 };
 
 /**
@@ -83,10 +113,9 @@ ProxyConnection.prototype.handleMessage = function(message) {
         eventName: eventName,
         request: message
       };
-    } else {
+    } else if ('ack' != eventName) {
       delete this.transactions[transactionId];
       this.emitEvent(transaction.eventName, transaction.request, message);
-
     }
   }
 };

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,0 +1,7 @@
+function Stream(id, pluginId, sessionId) {
+  this.id = id;
+  this.pluginId = pluginId;
+  this.sessionId = sessionId;
+}
+
+module.exports = Stream;


### PR DESCRIPTION
### Browser -> cm-janus
We should deny illegal actions/plugins.
We should instantiate handler per plugin and attach listener to specific `handleId` at that time. We should store it per connection.
- `Streaming`
  - `{"request":"watch"}` holds the stream id. 
- `AudioBridge`
  - ?


### Janus -> cm-janus
In particular, for each handle involving a PeerConnection Janus provides notifications about its current state. To do so, the following events may be received as well:

- `webrtcup`: ICE and DTLS succeeded, and so Janus correctly established a PeerConnection with the user/application;
  - trigger `onSubscribe`, `onPublish` events
- `media`: whether Janus is receiving (receiving: true/false) audio/video (type: "audio/video") on this PeerConnection;
- `hangup`: the PeerConnection was closed, either by Janus or by the user/application, and as such cannot be used anymore.
  - trigger `onUnSubscribe`, `onUnPublish` events

Above events could be intercepted and its data passed to cm applications via rpc calls.
