### PR TITLE
Add token/secret to HttpServer handlers and CMApiClient requests

### DIFF
--- a/lib/cm-api-client.js
+++ b/lib/cm-api-client.js
@@ -1,20 +1,25 @@
 var logger = require('./logger');
 var requestPromise = require('request-promise');
+var config = require('./config').asHash();
 
 /**
  * @param {String} baseUrl
+ * @param {String} apiKey
  */
-CMApiClient = function(baseUrl) {
+CMApiClient = function(baseUrl, apiKey) {
   this.baseUrl = baseUrl;
+  this.apiKey = apiKey;
 };
 
 /**
  * @param {String} action
- * @param {Object} data
+ * @param {Array} data
  * @returns {Promise}
  * @private
  */
 CMApiClient.prototype._request = function(action, data) {
+  data.unshift(this.apiKey);
+
   var options = {
     method: 'POST',
     uri: this.baseUrl + '/rpc/CM_Janus_RpcEndpoints.' + action,
@@ -28,71 +33,70 @@ CMApiClient.prototype._request = function(action, data) {
 };
 
 /**
- * @param {String} streamName
- * @param {String} clientKey
+ * @param {String} streamChannelKey
+ * @param {String} streamKey
  * @param {Number} start
  * @param {JSON} [data]
  * @returns {Promise}
  */
-CMApiClient.prototype.publish = function(streamName, clientKey, start, data) {
-  return this._request('publish', {
-    streamName: streamName,
-    clientKey: clientKey,
-    start: +start,
-    data: data || {}
-  });
+CMApiClient.prototype.publish = function(streamChannelKey, streamKey, start, data) {
+  return this._request('publish', [
+    streamChannelKey,
+    streamKey,
+    +start,
+    data || {}
+  ]);
 };
 
 /**
- * @param {String} streamName
- * @param {String} clientKey
+ * @param {String} streamChannelKey
+ * @param {String} streamKey
  * @param {Number} start
  * @param {JSON} [data]
  * @returns {Promise}
  */
-CMApiClient.prototype.subscribe = function(streamName, clientKey, start, data) {
-  return this._request('subscribe', {
-    streamName: streamName,
-    clientKey: clientKey,
-    start: +start,
-    data: data || {}
-  });
+CMApiClient.prototype.subscribe = function(streamChannelKey, streamKey, start, data) {
+  return this._request('subscribe', [
+    streamChannelKey,
+    streamKey,
+    +start,
+    data || {}
+  ]);
 };
 
 /**
- * @param {String} streamName
- * @param {String} clientKey
- * @returns {Promise}
+ * @param {String} streamChannelKey
+ * @param {String} streamKey
  */
-CMApiClient.prototype.removeStream = function(streamName, clientKey) {
-  return this._request('removeStream', {
-    streamName: streamName,
-    clientKey: clientKey
-  });
-};
-
-/**
- * @param {String} sessionId
- * @param {String} streamChannelName
- * @returns {Promise}
- */
-CMApiClient.prototype.authPublish = function(sessionId, streamChannelName) {
-  return this._request('authPublish', {
-    sessionId: sessionId,
-    streamChannelName: streamChannelName
-  });
+CMApiClient.prototype.removeStream = function(streamChannelKey, streamKey) {
+  return this._request('removeStream', [
+    streamChannelKey,
+    streamKey
+  ]);
 };
 
 /**
  * @param {String} sessionId
- * @param {String} streamChannelName
+ * @param {String} streamChannelKey
  * @returns {Promise}
  */
-CMApiClient.prototype.authSubscribe = function(sessionId, streamChannelName) {
-  return this._request('authSubscribe', {
-    sessionId: sessionId,
-    streamChannelName: streamChannelName
-  });
+CMApiClient.prototype.authPublish = function(sessionId, streamChannelKey) {
+  return this._request('authPublish', [
+    sessionId,
+    streamChannelKey
+  ]);
+};
+
+/**
+ * @param {String} sessionId
+ * @param {String} streamChannelKey
+ * @returns {Promise}
+ */
+CMApiClient.prototype.authSubscribe = function(sessionId, streamChannelKey) {
+  return this._request('authSubscribe', [
+    sessionId,
+    streamChannelKey
+  ]);
 };
 
 module.exports = CMApiClient;

--- a/lib/cm-api-client.js
+++ b/lib/cm-api-client.js
@@ -99,4 +99,4 @@ CMApiClient.prototype.authSubscribe = function(sessionId, streamChannelKey) {
   ]);
 };
 
-module.exports = CMApiClient;
+module.exports = new CMApiClient(config['httpServer']['apiKey'], config['httpServer']['apiKey']);

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -43,7 +43,8 @@ HttpServer.prototype.installRoutes = function(router) {
 
   router.use(function(req, res, next) {
     logger.debug('request ' + req.path);
-    if (req.body['apiKey'] != self.apiKey) {
+    var incomingApiKey = req.get('Api-Key');
+    if (incomingApiKey === undefined || incomingApiKey !== self.apiKey) {
       res.sendStatus(403);
     } else {
       next();

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -43,8 +43,8 @@ HttpServer.prototype.installRoutes = function(router) {
 
   router.use(function(req, res, next) {
     logger.debug('request ' + req.path);
-    var incomingApiKey = req.get('Api-Key');
-    if (incomingApiKey === undefined || incomingApiKey !== self.apiKey) {
+    var apiKey = req.get('Api-Key');
+    if (!apiKey || apiKey !== self.apiKey) {
       res.sendStatus(403);
     } else {
       next();


### PR DESCRIPTION
- Consider using the same `apiKey` for `HttpServer` and `CMApiClient`
- Use header for `HttpServer` `apiKey` authentication
- Send `apiKey` as first param in all `CMApiClient` `requests`
Example
```js
{
    method: 'CM_Janus_RpcEndpoints.publish',
    params: ['apiKey', 'streamKey', '...']
}
```
For other signatures check https://github.com/tomaszdurka/CM/blob/issue-1965/library/CM/Janus/RpcEndpoints.php