### PR TITLE
Cleaning

### DIFF
--- a/lib/janus-proxy.js
+++ b/lib/janus-proxy.js
@@ -6,7 +6,6 @@ var ProxyConnection = require('./proxy-connection');
 
 var config = require('./config');
 var logger = require('./logger');
-var auth = require('./auth');
 
 /**
  * @param {Number} listenPort

--- a/lib/plugin/streaming.js
+++ b/lib/plugin/streaming.js
@@ -19,19 +19,21 @@ util.inherits(PluginStreaming, PluginAbstract);
  * @returns {Promise}
  */
 PluginStreaming.prototype.processMessage = function(message) {
-  if ('message' === message.janus && 'create' === message.body.request) {
+  var janusMessage = message['janus'];
+
+  if ('message' === janusMessage && 'create' === message.body.request) {
     return this.onCreate(message);
   }
-  if ('message' === message.janus && 'watch' === message.body.request) {
+  if ('message' === janusMessage && 'watch' === message.body.request) {
     return this.onWatch(message);
   }
-  if ('webrtcup' === message.janus) {
+  if ('webrtcup' === janusMessage) {
     return this.onWebrtcup(message);
   }
-  if ('hangup' === message.janus) {
+  if ('hangup' === janusMessage) {
     return this.onHangup(message);
   }
-  if ('detach' === message.janus) {
+  if ('detach' === janusMessage) {
     return this.onHangup(message);
   }
   return Promise.resolve();

--- a/lib/plugin/streaming.js
+++ b/lib/plugin/streaming.js
@@ -45,7 +45,7 @@ PluginStreaming.prototype.onCreate = function(message) {
   var self = this;
   return auth.canPublish(message.token, message.body.id)
     .then(function() {
-      self.proxyConnection.transactions.add(message.transaction, function(response) {
+      self.proxyConnection.transactions.add(message['transaction'], function(response) {
         self.stream = Stream.generate(message.body.id, self.proxyConnection);
         logger.info('adding stream', self.stream);
         streams.add(self.stream);
@@ -62,7 +62,7 @@ PluginStreaming.prototype.onWatch = function(message) {
   var self = this;
   return auth.canSubscribe(message.session_id, message.body.id)
     .then(function() {
-      self.proxyConnection.transactions.add(message.transaction, function(response) {
+      self.proxyConnection.transactions.add(message['transaction'], function(response) {
         self.stream = Stream.generate(message.body.id, self.proxyConnection);
         logger.info('adding stream', self.stream);
         streams.add(self.stream);

--- a/lib/plugin/streaming.js
+++ b/lib/plugin/streaming.js
@@ -21,10 +21,10 @@ util.inherits(PluginStreaming, PluginAbstract);
 PluginStreaming.prototype.processMessage = function(message) {
   var janusMessage = message['janus'];
 
-  if ('message' === janusMessage && 'create' === message.body.request) {
+  if ('message' === janusMessage && 'create' === message['body']['request']) {
     return this.onCreate(message);
   }
-  if ('message' === janusMessage && 'watch' === message.body.request) {
+  if ('message' === janusMessage && 'watch' === message['body']['request']) {
     return this.onWatch(message);
   }
   if ('webrtcup' === janusMessage) {
@@ -45,10 +45,10 @@ PluginStreaming.prototype.processMessage = function(message) {
  */
 PluginStreaming.prototype.onCreate = function(message) {
   var self = this;
-  return auth.canPublish(message.token, message.body.id)
+  return auth.canPublish(message['token'], message['body']['id'])
     .then(function() {
       self.proxyConnection.transactions.add(message['transaction'], function(response) {
-        self.stream = Stream.generate(message.body.id, self.proxyConnection);
+        self.stream = Stream.generate(message['body']['id'], self.proxyConnection);
         logger.info('adding stream', self.stream);
         streams.add(self.stream);
       });
@@ -62,10 +62,10 @@ PluginStreaming.prototype.onCreate = function(message) {
  */
 PluginStreaming.prototype.onWatch = function(message) {
   var self = this;
-  return auth.canSubscribe(message.session_id, message.body.id)
+  return auth.canSubscribe(message['session_id'], message['body']['id'])
     .then(function() {
       self.proxyConnection.transactions.add(message['transaction'], function(response) {
-        self.stream = Stream.generate(message.body.id, self.proxyConnection);
+        self.stream = Stream.generate(message['body']['id'], self.proxyConnection);
         logger.info('adding stream', self.stream);
         streams.add(self.stream);
       });

--- a/lib/proxy-connection.js
+++ b/lib/proxy-connection.js
@@ -30,14 +30,15 @@ ProxyConnection.prototype.processMessage = function(message) {
   if (pluginId) {
     return this.getPlugin(pluginId).processMessage(message);
   }
+  var janusMessage = message['janus'];
 
-  if ('create' === message.janus) {
+  if ('create' === janusMessage) {
     return this.onCreate(message);
   }
-  if ('attach' === message.janus) {
+  if ('attach' === janusMessage) {
     return this.onAttach(message);
   }
-  if ('destroy' === message.janus) {
+  if ('destroy' === janusMessage) {
     return this.onDestroy(message);
   }
 

--- a/lib/proxy-connection.js
+++ b/lib/proxy-connection.js
@@ -20,9 +20,9 @@ function ProxyConnection(browserConnection, janusConnection) {
 }
 
 ProxyConnection.prototype.processMessage = function(message) {
-  if (message.transaction) {
-    if (this.transactions.find(message.transaction)) {
-      this.transactions.execute(message.transaction, message);
+  if (message['transaction']) {
+    if (this.transactions.find(message['transaction'])) {
+      this.transactions.execute(message['transaction'], message);
     }
   }
 
@@ -50,7 +50,7 @@ ProxyConnection.prototype.processMessage = function(message) {
  */
 ProxyConnection.prototype.onCreate = function(message) {
   var self = this;
-  this.transactions.add(message.transaction, function(response) {
+  this.transactions.add(message['transaction'], function(response) {
     switch (response.janus) {
       case 'success':
         self.sessionId = response.data.id;
@@ -69,7 +69,7 @@ ProxyConnection.prototype.onCreate = function(message) {
  */
 ProxyConnection.prototype.onDestroy = function(message) {
   var self = this;
-  this.transactions.add(message.transaction, function(response) {
+  this.transactions.add(message['transaction'], function(response) {
     if ('success' == response.janus) {
       self.sessionId = null;
     }
@@ -88,7 +88,7 @@ ProxyConnection.prototype.onAttach = function(message) {
     return Promise.reject('Disallowed plugin ' + message.plugin);
   }
 
-  this.transactions.add(message.transaction, function(response) {
+  this.transactions.add(message['transaction'], function(response) {
     if (response.janus === 'success') {
       var pluginId = response.data.id;
       self.plugins[pluginId] = self.pluginFactory(message.plugin, pluginId);

--- a/lib/proxy-connection.js
+++ b/lib/proxy-connection.js
@@ -84,8 +84,8 @@ ProxyConnection.prototype.onDestroy = function(message) {
  */
 ProxyConnection.prototype.onAttach = function(message) {
   var self = this;
-  if (!this.isAllowedPlugin(message.plugin)) {
-    return Promise.reject('Disallowed plugin ' + message.plugin);
+  if (!this.isAllowedPlugin(message['plugin'])) {
+    return Promise.reject('Disallowed plugin ' + message['plugin']);
   }
 
   this.transactions.add(message['transaction'], function(response) {

--- a/lib/proxy-connection.js
+++ b/lib/proxy-connection.js
@@ -65,7 +65,7 @@ ProxyConnection.prototype._processMessage = function(message) {
 ProxyConnection.prototype.onCreate = function(message) {
   this.transactions.add(message['transaction'], function(response) {
     if ('success' == response['janus']) {
-      this.sessionId = response.data.id;
+      this.sessionId = response['data']['id'];
     }
   }.bind(this));
   return Promise.resolve(message);

--- a/lib/proxy-connection.js
+++ b/lib/proxy-connection.js
@@ -1,7 +1,6 @@
 var _ = require('underscore');
 var Transactions = require('./transactions');
 var PluginStreaming = require('./plugin/streaming');
-var auth = require('./auth');
 var logger = require('./logger');
 var streams = require('./streams');
 var cmApiClient = require('./cm-api-client');

--- a/lib/proxy-connection.js
+++ b/lib/proxy-connection.js
@@ -51,9 +51,9 @@ ProxyConnection.prototype.processMessage = function(message) {
 ProxyConnection.prototype.onCreate = function(message) {
   var self = this;
   this.transactions.add(message['transaction'], function(response) {
-    switch (response.janus) {
+    switch (response['janus']) {
       case 'success':
-        self.sessionId = response.data.id;
+        self.sessionId = response['data']['id'];
         break;
       case 'error':
         //TODO Inform user that create didn't work. Should we close here the connection?
@@ -70,7 +70,7 @@ ProxyConnection.prototype.onCreate = function(message) {
 ProxyConnection.prototype.onDestroy = function(message) {
   var self = this;
   this.transactions.add(message['transaction'], function(response) {
-    if ('success' == response.janus) {
+    if ('success' == response['janus']) {
       self.sessionId = null;
     }
     self.close();
@@ -89,9 +89,9 @@ ProxyConnection.prototype.onAttach = function(message) {
   }
 
   this.transactions.add(message['transaction'], function(response) {
-    if (response.janus === 'success') {
-      var pluginId = response.data.id;
-      self.plugins[pluginId] = self.pluginFactory(message.plugin, pluginId);
+    if (response['janus'] === 'success') {
+      var pluginId = response['data']['id'];
+      self.plugins[pluginId] = self.pluginFactory(message['plugin'], pluginId);
     }
   });
   return Promise.resolve(message);


### PR DESCRIPTION
- Optimise the excessive usage of `message.janus`. Store it in a variable where is needed.
- Replace all accesses to janus messages from `message.transaction` to `message['transaction']`.

@fvovan This one is a good starting point to keep up yourself with the changes.