### PR TITLE
Make Logger more oop

### DIFF
--- a/lib/cm-api-client.js
+++ b/lib/cm-api-client.js
@@ -32,12 +32,12 @@ CMApiClient.prototype._request = function(action, data) {
   serviceLocator.get('logger').info('cm-api', 'request', options.uri, options.body);
   return requestPromise(options)
     .catch(function(error) {
-      throw new Error('cm-api error: ' +  error['message']);
+      throw new Error('cm-api error: ' + error['message']);
     })
     .then(function(response) {
       serviceLocator.get('logger').info('cm-api', 'response', response.body);
       if (response['error']) {
-        throw new Error('cm-api error: ' +  response['error']['msg']);
+        throw new Error('cm-api error: ' + response['error']['msg']);
       }
       return response['success']['result'];
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var CMApiClient = require('./cm-api-client');
 var Auth = require('./auth');
 var Streams = require('./streams');
 var Logger = require('./logger');
+var fs = require('fs');
 
 function Application(config) {
   this.config = config;
@@ -10,8 +11,16 @@ function Application(config) {
 
 Application.prototype.registerServices = function() {
   serviceLocator.register('logger', function() {
-    var logger = new Logger(__dirname + '/../' + this.config['logPath'], 'app');
-    return logger.getHandler();
+    var logger = new Logger('app');
+    logger
+      .pipe(Logger.backends.nodeConsole.formatMinilog)
+      .pipe(Logger.backends.nodeConsole);
+
+    var logFilePath = __dirname + '/../' + this.config['logPath'];
+    var stream = fs.createWriteStream(logFilePath, {flags: 'a', defaultEncoding: 'utf8'});
+    logger
+      .pipe(stream);
+    return logger;
   }.bind(this));
 
   serviceLocator.register('auth', function() {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,23 +1,49 @@
 var minilog = require('minilog');
-var fs = require('fs');
+var Stream = require('stream');
 
 /**
- * @param {String} logFilePath
  * @param {String} name
  * @constructor
  */
-function Logger(logFilePath, name) {
-  var stream = fs.createWriteStream(logFilePath, {flags: 'a', defaultEncoding: 'utf8'});
-  minilog.enable(); //instead of pipe to console
-  minilog.pipe(stream);
-  this._logger = minilog(name);
+function Logger(name) {
+  this._name = name;
+  this._transform = new minilog.Transform();
+  this.debug = this.write.bind(this, 'debug');
+  this.info = this.write.bind(this, 'info');
+  this.warn = this.write.bind(this, 'warn');
+  this.error = this.write.bind(this, 'error');
 }
 
 /**
+ * @param dest
  * @returns {Transform}
  */
-Logger.prototype.getHandler = function() {
-  return this._logger;
+Logger.prototype.pipe = function(dest) {
+  if (dest instanceof Stream) {
+    return this._transform.pipe(new minilog.Stringifier()).pipe(dest);
+  } else {
+    return this._transform.pipe(dest);
+  }
 };
 
+/**
+ * @param from
+ */
+Logger.prototype.unpipe = function(from) {
+  this._transform.unpipe(from);
+};
+
+/**
+ * @param {String} level
+ * @param [arg1]
+ * @param [arg2]
+ */
+Logger.prototype.write = function(level, arg1, arg2) {
+  var args = Array.prototype.slice.call(arguments, 1);
+  this._transform.write(this._name, level, args);
+};
+
+Logger.backends = minilog.backends;
+
 module.exports = Logger;
+


### PR DESCRIPTION
Allow to create instances of and mock Logger class.

Service registry:
```js
var Logger = require('./logger');
var serviceLocator = require('./service-locator');
serviceLocator.register('logger', function() {
  var logger = new Logger();
  var logFilePath = __dirname + '/../' + this.config['logPath']
  var stream = fs.createWriteStream(logFilePath, {flags: 'a', defaultEncoding: 'utf8'});
  logger.pipe(stream);
  return logger;
});
```

Not sure if it's possible with minilog which signature is quite strange (unless you know different way than we use).
