### PR TITLE
Allow to use arbitrary paths for log

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var Auth = require('./auth');
 var Streams = require('./streams');
 var Logger = require('./logger');
 var fs = require('fs');
+var path = require('path');
 
 function Application(config) {
   this.config = config;
@@ -16,7 +17,7 @@ Application.prototype.registerServices = function() {
       .pipe(Logger.backends.nodeConsole.formatMinilog)
       .pipe(Logger.backends.nodeConsole);
 
-    var logFilePath = __dirname + '/../' + this.config['logPath'];
+    var logFilePath = path.resolve(path.dirname(__dirname), this.config['logPath']);
     var stream = fs.createWriteStream(logFilePath, {flags: 'a', defaultEncoding: 'utf8'});
     logger
       .pipe(stream);


### PR DESCRIPTION
After having tried to run as a non-root user I found out that the log location needs be in a place where the app user has rights to write to

Ideally, this is configurable. A common place where log files are stored in our setup is `/var/log/<appname>`

As-of-now, this is only possible by prefixing the path with as many `../` as the depth of where the app is installed, e.g. `logPath: '../../../../../../../../home/vagrant/app.log'` because of https://github.com/cargomedia/cm-janus/blob/master/lib/index.js#L19