### PR TITLE
Global error handler in tests

### DIFF
--- a/test/helpers/global-error-handler.js
+++ b/test/helpers/global-error-handler.js
@@ -1,0 +1,3 @@
+process.on("unhandledRejection", function(reason) {
+  throw reason;
+});

--- a/test/spec/cm-api-client.js
+++ b/test/spec/cm-api-client.js
@@ -1,5 +1,6 @@
 var assert = require('chai').assert;
 var nock = require('nock');
+require('../helpers/global-error-handler');
 var Logger = require('../../lib/logger');
 var serviceLocator = require('../../lib/service-locator');
 

--- a/test/spec/job-manager.js
+++ b/test/spec/job-manager.js
@@ -1,5 +1,6 @@
 var assert = require('chai').assert;
 var sinon = require('sinon');
+require('../helpers/global-error-handler');
 var path = require('path');
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require("fs"));

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -1,4 +1,5 @@
 var assert = require('chai').assert;
+require('../helpers/global-error-handler');
 var Auth = require('../../lib/auth');
 var Promise = require('bluebird');
 

--- a/test/unit/cm-api-client.js
+++ b/test/unit/cm-api-client.js
@@ -1,4 +1,5 @@
 var assert = require('chai').assert;
+require('../helpers/global-error-handler');
 var CMApiClient = require('../../lib/cm-api-client');
 var Promise = require('bluebird');
 var sinon = require('sinon');

--- a/test/unit/connection.js
+++ b/test/unit/connection.js
@@ -1,4 +1,5 @@
 var assert = require('chai').assert;
+require('../helpers/global-error-handler');
 var WebSocketServer = require('../helpers/websocket').Server;
 var WebSocket = require('../helpers/websocket').Client;
 var Logger = require('../../lib/logger');

--- a/test/unit/service-locator.js
+++ b/test/unit/service-locator.js
@@ -1,4 +1,5 @@
 var assert = require('chai').assert;
+require('../helpers/global-error-handler');
 var serviceLocator = require('../../lib/service-locator');
 var sinon = require('sinon');
 


### PR DESCRIPTION
Currently if an error is thrown inside a promise without `catch` block, we loose it and tests exit by timeout.