### PR TITLE
streaming: close of undefined

### DIFF
--- a/lib/plugin/streaming.js
+++ b/lib/plugin/streaming.js
@@ -50,7 +50,7 @@ PluginStreaming.prototype.onCreate = function(message) {
           serviceLocator.get('streams').add(self.stream);
         })
         .catch(function(error) {
-          self.stream.connection.close();
+          self.proxyConnection.close();
           throw new JanusError.Error('Cannot publish: ', error);
         });
     } else {


### PR DESCRIPTION
@tomaszdurka @vogdb @fvovan 

```
Unhandled rejection TypeError: Cannot read property 'close' of undefined
    at /usr/lib/node_modules/cm-janus/lib/plugin/streaming.js:53:33
    at tryCatcher (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromises (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:697:14)
    at Async._drainQueue (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:367:17)
```