### PR TITLE
Fix: properly cleanup websocket connection between cm-janus and janus

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -34,7 +34,7 @@ function Connection(identifier, webSocket) {
 util.inherits(Connection, EventEmitter);
 
 Connection.prototype.close = function() {
-  this.webSocket.close();
+  this.webSocket.terminate();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cm-janus",
   "description": "",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "",

--- a/test/helpers/websocket.js
+++ b/test/helpers/websocket.js
@@ -33,6 +33,10 @@ WebSocketClient.prototype.close = function() {
   this._webSocket.close();
 };
 
+WebSocketClient.prototype.terminate = function() {
+  this._webSocket.close();
+};
+
 module.exports = {
   Server: MockServer,
   Client: WebSocketClient


### PR DESCRIPTION
My test shows that if websocket connection is closed between any `client` (studio-agent) and the `cm-janus` then the connection between `cm-janus` and `janus` is still alive?

could you verify?