### PR TITLE
Fix chanelData read in streaming pluign

### DIFF
--- a/lib/plugin/streaming.js
+++ b/lib/plugin/streaming.js
@@ -45,7 +45,7 @@ PluginStreaming.prototype.onCreate = function(message) {
   this.proxyConnection.transactions.add(message['transaction'], function(response) {
     if (self._isSuccessResponse(response)) {
       self.stream = Stream.generate(message['body']['id'], self);
-      return serviceLocator.get('cm-api-client').publish(self.stream.channelName, self.stream.id, Date.now(), self.proxyConnection.sessionData, message['channelData'])
+      return serviceLocator.get('cm-api-client').publish(self.stream.channelName, self.stream.id, Date.now(), self.proxyConnection.sessionData, message['body']['channel_data'])
         .then(function() {
           serviceLocator.get('logger').info('adding stream', self.stream);
           serviceLocator.get('streams').add(self.stream);


### PR DESCRIPTION
Should use `message['body']['channel_data']` instead of `message['channelData']`.