### PR TITLE
RPC Error logging

### DIFF
--- a/lib/cm-api-client.js
+++ b/lib/cm-api-client.js
@@ -41,10 +41,12 @@ CMApiClient.prototype._request = function(action, data) {
       throw new Error('cm-api error: ' + error['message']);
     })
     .then(function(response) {
-      serviceLocator.get('logger').info('cm-api', 'response', response.body);
-      if (response['error']) {
-        throw new Error('cm-api error: ' + response['error']['msg']);
+      var error = response['error'];
+      if (error) {
+        serviceLocator.get('logger').error('cm-api', 'response', response);
+        throw new Error('cm-api error: ' + error['type'] + '. ' + error['msg']);
       }
+      serviceLocator.get('logger').info('cm-api', 'response', response.body);
       return response['success']['result'];
     });
 };

--- a/test/unit/cm-api-client.js
+++ b/test/unit/cm-api-client.js
@@ -1,5 +1,6 @@
 var assert = require('chai').assert;
 require('../helpers/global-error-handler');
+var Logger = require('../../lib/logger');
 var CMApiClient = require('../../lib/cm-api-client');
 var Promise = require('bluebird');
 var sinon = require('sinon');
@@ -23,19 +24,13 @@ describe('CmApiClient unit tests', function() {
     var apiKey = 'fooKey';
     var cmApiClient = new CMApiClient(baseUri, apiKey);
     var serviceLocator = require('../../lib/service-locator.js');
-
-    var logger = {
-      info: function() {
-      }
-    };
-
     var action = 'foo';
     var sentData = ['bar', 'baz'];
 
     before(function() {
       serviceLocator.reset();
       serviceLocator.register('logger', function() {
-        return logger;
+        return new Logger();
       });
     });
 
@@ -67,12 +62,12 @@ describe('CmApiClient unit tests', function() {
 
     it('works with response with error', function(done) {
       var requestPromiseMock = sinon.stub(cmApiClient, '_requestPromise', function() {
-        return Promise.resolve({body: 'bodyErr', error: {msg: 'disaster'}});
+        return Promise.resolve({body: 'bodyErr', error: {msg: 'msg', type: 'type'}});
       });
 
       cmApiClient._request(action, sentData).catch(function(err) {
         assert.instanceOf(err, Error);
-        assert.strictEqual(err.message, 'cm-api error: disaster');
+        assert.strictEqual(err.message, 'cm-api error: type. msg');
         assert.isTrue(requestPromiseMock.calledOnce);
         done();
       });

--- a/test/unit/cm-api-client.js
+++ b/test/unit/cm-api-client.js
@@ -11,17 +11,17 @@ describe('CmApiClient unit tests', function() {
   it('is created properly', function() {
     var baseUrl = 'http://cm.dev/';
     var apiKey = 'foo';
-    var cmHttpClient = new CMApiClient(baseUrl, apiKey);
+    var cmApiClient = new CMApiClient(baseUrl, apiKey);
 
-    assert.instanceOf(cmHttpClient, CMApiClient, 'has proper type');
-    assert.strictEqual(cmHttpClient.baseUrl, baseUrl, 'has proper baseUrl');
-    assert.strictEqual(cmHttpClient.apiKey, apiKey, 'has proper apiKey');
+    assert.instanceOf(cmApiClient, CMApiClient, 'has proper type');
+    assert.strictEqual(cmApiClient.baseUrl, baseUrl, 'has proper baseUrl');
+    assert.strictEqual(cmApiClient.apiKey, apiKey, 'has proper apiKey');
   });
 
   describe('_request()', function() {
     var baseUri = 'http://cm.dev/';
     var apiKey = 'fooKey';
-    var cmHttpClient = new CMApiClient(baseUri, apiKey);
+    var cmApiClient = new CMApiClient(baseUri, apiKey);
     var serviceLocator = require('../../lib/service-locator.js');
 
     var logger = {
@@ -44,7 +44,7 @@ describe('CmApiClient unit tests', function() {
     });
 
     it('works with successful response', function(done) {
-      var requestPromiseMock = sinon.stub(cmHttpClient, '_requestPromise', function(options) {
+      var requestPromiseMock = sinon.stub(cmApiClient, '_requestPromise', function(options) {
         assert.deepEqual(options, {
           method: 'POST',
           uri: baseUri,
@@ -57,7 +57,7 @@ describe('CmApiClient unit tests', function() {
         return Promise.resolve({body: 'body', success: {result: 'quux'}});
       });
 
-      cmHttpClient._request(action, sentData).then(function(res) {
+      cmApiClient._request(action, sentData).then(function(res) {
         assert.strictEqual(res, 'quux');
         assert.isTrue(requestPromiseMock.calledOnce);
         done();
@@ -66,11 +66,11 @@ describe('CmApiClient unit tests', function() {
     });
 
     it('works with response with error', function(done) {
-      var requestPromiseMock = sinon.stub(cmHttpClient, '_requestPromise', function() {
+      var requestPromiseMock = sinon.stub(cmApiClient, '_requestPromise', function() {
         return Promise.resolve({body: 'bodyErr', error: {msg: 'disaster'}});
       });
 
-      cmHttpClient._request(action, sentData).catch(function(err) {
+      cmApiClient._request(action, sentData).catch(function(err) {
         assert.instanceOf(err, Error);
         assert.strictEqual(err.message, 'cm-api error: disaster');
         assert.isTrue(requestPromiseMock.calledOnce);
@@ -80,11 +80,11 @@ describe('CmApiClient unit tests', function() {
     });
 
     it('works with completely failed request', function(done) {
-      var requestPromiseMock = sinon.stub(cmHttpClient, '_requestPromise', function() {
+      var requestPromiseMock = sinon.stub(cmApiClient, '_requestPromise', function() {
         return Promise.reject(new Error('request failed'));
       });
 
-      cmHttpClient._request(action, sentData).catch(function(err) {
+      cmApiClient._request(action, sentData).catch(function(err) {
         assert.instanceOf(err, Error);
         assert.strictEqual(err.message, 'cm-api error: request failed');
         assert.isTrue(requestPromiseMock.calledOnce);
@@ -95,19 +95,19 @@ describe('CmApiClient unit tests', function() {
   });
 
   describe('isValidUser()', function() {
-    var cmHttpClient = new CMApiClient('http://cm.dev/', 'foo');
+    var cmApiClient = new CMApiClient('http://cm.dev/', 'foo');
     var userData = {foo: 'bar'};
 
     it('works when returns true', function() {
-      var successStub = sinon.stub(cmHttpClient, '_request').returns(Promise.resolve(true));
-      cmHttpClient.isValidUser(userData);
+      var successStub = sinon.stub(cmApiClient, '_request').returns(Promise.resolve(true));
+      cmApiClient.isValidUser(userData);
       assert.isTrue(successStub.withArgs('isValidUser', [userData]).calledOnce);
       successStub.restore();
     });
 
     it('works when returns false', function(done) {
-      var failStub = sinon.stub(cmHttpClient, '_request').returns(Promise.resolve(false));
-      cmHttpClient.isValidUser(userData).catch(function(err) {
+      var failStub = sinon.stub(cmApiClient, '_request').returns(Promise.resolve(false));
+      cmApiClient.isValidUser(userData).catch(function(err) {
         assert.instanceOf(err, Error);
         assert.strictEqual(err.message, 'Not valid user');
         assert.isTrue(failStub.withArgs('isValidUser', [userData]).calledOnce);
@@ -117,7 +117,7 @@ describe('CmApiClient unit tests', function() {
   });
 
   describe('publish()', function() {
-    var cmHttpClient = new CMApiClient('http://cm.dev/', 'apiKey');
+    var cmApiClient = new CMApiClient('http://cm.dev/', 'apiKey');
     var streamChannelKey = 'scKey';
     var streamKey = 'stKey';
     var start = 123;
@@ -125,36 +125,36 @@ describe('CmApiClient unit tests', function() {
     var channelData = 'channelData';
 
     it('passes params to request correctly', function() {
-      var requestStub = sinon.stub(cmHttpClient, '_request').returns(Promise.resolve(true));
-      cmHttpClient.publish(streamChannelKey, streamKey, start, sessionData, channelData);
+      var requestStub = sinon.stub(cmApiClient, '_request').returns(Promise.resolve(true));
+      cmApiClient.publish(streamChannelKey, streamKey, start, sessionData, channelData);
       assert.isTrue(requestStub.withArgs('publish', [streamChannelKey, streamKey, start, sessionData, channelData]).calledOnce);
       requestStub.restore();
     });
   });
 
   describe('subscribe()', function() {
-    var cmHttpClient = new CMApiClient('http://cm.dev/', 'apiKey');
+    var cmApiClient = new CMApiClient('http://cm.dev/', 'apiKey');
     var streamChannelKey = 'scKey';
     var streamKey = 'stKey';
     var start = 123;
     var userData = {foo: 'bar'};
 
     it('passes params to request correctly', function() {
-      var requestStub = sinon.stub(cmHttpClient, '_request').returns(Promise.resolve(true));
-      cmHttpClient.subscribe(streamChannelKey, streamKey, start, userData);
+      var requestStub = sinon.stub(cmApiClient, '_request').returns(Promise.resolve(true));
+      cmApiClient.subscribe(streamChannelKey, streamKey, start, userData);
       assert.isTrue(requestStub.withArgs('subscribe', [streamChannelKey, streamKey, start, userData]).calledOnce);
       requestStub.restore();
     });
   });
 
   describe('removeStream()', function() {
-    var cmHttpClient = new CMApiClient('http://cm.dev/', 'apiKey');
+    var cmApiClient = new CMApiClient('http://cm.dev/', 'apiKey');
     var streamChannelKey = 'scKey';
     var streamKey = 'stKey';
 
     it('passes params to request correctly', function() {
-      var requestStub = sinon.stub(cmHttpClient, '_request').returns(Promise.resolve(true));
-      cmHttpClient.removeStream(streamChannelKey, streamKey);
+      var requestStub = sinon.stub(cmApiClient, '_request').returns(Promise.resolve(true));
+      cmApiClient.removeStream(streamChannelKey, streamKey);
       assert.isTrue(requestStub.withArgs('removeStream', [streamChannelKey, streamKey]).calledOnce);
       requestStub.restore();
     });


### PR DESCRIPTION
When an RPC call to the CM application fails, the application responds with a JSON structure of this form:
```json
{"type": "CM_Exception_AuthRequired", "msg": "Internal Server Error", "isPublic": false}
```

Afaik cm-janus currently only displays the `msg`. Logging additionally the `type` would be handy.
@tomaszdurka @fvovan @vogdb wdyt?