### PR TITLE
rpc_removeStream never called

### DIFF
--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -75,6 +75,7 @@ PluginStreaming.prototype.onWebrtcup = function(message) {
 
 PluginStreaming.prototype.removeStream = function() {
   if (this.stream) {
+    serviceLocator.get('cm-api-client').removeStream(this.stream.channelName, this.stream.id);
     var streams = serviceLocator.get('streams');
     if (streams.has(this.stream.id)) {
       streams.remove(this.stream);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cm-janus",
   "description": "",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "",

--- a/test/spec/cm-api-client.js
+++ b/test/spec/cm-api-client.js
@@ -63,6 +63,21 @@ describe('CmApiClient spec tests', function() {
     });
   });
 
+  it('removeStream', function(done) {
+    var url = 'http://localhost:8080';
+    var action = 'removeStream';
+    var apiKey = 'test';
+    var params = ['streamChannelKey', 'streamKey'];
+
+    mockRequest(url, action, apiKey, params);
+
+    var client = new CmApiClient(url, apiKey);
+    client.removeStream.apply(client, params).then(function(result) {
+      assert.isTrue(result);
+      done();
+    });
+  });
+
   it('isValidUser', function(done) {
     var url = 'http://localhost:8080';
     var action = 'isValidUser';

--- a/test/spec/janus/plugin/streaming.js
+++ b/test/spec/janus/plugin/streaming.js
@@ -28,7 +28,7 @@ describe('PluginStreaming', function() {
     serviceLocator.register('cm-api-client', cmApiClient);
     streams = sinon.createStubInstance(Streams);
     serviceLocator.register('streams', streams);
-    httpClient = sinon.createStubInstance(JanusHttpClient)
+    httpClient = sinon.createStubInstance(JanusHttpClient);
     serviceLocator.register('http-client', httpClient);
   });
 
@@ -79,7 +79,7 @@ describe('PluginStreaming', function() {
         sinon.stub(cmApiClient, 'publish', function() {
           return Promise.resolve();
         });
-    });
+      });
 
       it('should set stream', function(done) {
         executeTransactionCallback().finally(function() {
@@ -202,7 +202,7 @@ describe('PluginStreaming', function() {
     var stream;
 
     beforeEach(function() {
-      stream = sinon.createStubInstance(Stream);
+      stream = new Stream('stream-id', 'channel-name', plugin);
       plugin.stream = stream;
       streams.has.returns(true);
     });
@@ -218,6 +218,13 @@ describe('PluginStreaming', function() {
       it('should remove stream from streams', function() {
         expect(streams.has.withArgs(stream.id).calledOnce).to.be.equal(true);
         expect(streams.remove.withArgs(stream).calledOnce).to.be.equal(true);
+      });
+
+      it('should call cmApiClient removeStream', function() {
+        expect(cmApiClient.removeStream.calledOnce).to.be.equal(true);
+        var args = cmApiClient.removeStream.firstCall.args;
+        expect(args[0]).to.be.equal('channel-name');
+        expect(args[1]).to.be.equal('stream-id');
       });
     });
   })


### PR DESCRIPTION
During testing we experienced that while the `publish()` and `subscribe()` endpoints are called it seems like `rpc_removeStream()` is not!

Could reproduce this when closing WebSocket connection to cm-janus.

@tomaszdurka can you look into this and/or reassign?