### PR TITLE
Support switch event for video plugin

### DIFF
--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -24,7 +24,7 @@ PluginStreaming.prototype.processMessage = function(message) {
   }
 
   if ('webrtcup' === janusMessage) {
-    return this.onWebrtcup(message);
+    return this.subscribe(message);
   }
 
   return Promise.resolve(message);
@@ -60,7 +60,7 @@ PluginStreaming.prototype.onCreate = function(message) {
  * @param {Object} message
  * @returns {Promise}
  */
-PluginStreaming.prototype.onWebrtcup = function(message) {
+PluginStreaming.prototype.subscribe = function(message) {
   var plugin = this;
   return serviceLocator.get('cm-api-client').subscribe(plugin.stream.channelName, plugin.stream.id, Date.now() / 1000, plugin.session.data)
     .then(function() {

--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -23,6 +23,10 @@ PluginVideo.prototype.processMessage = function(message) {
     return this.onWatch(message);
   }
 
+  if ('message' === janusMessage && 'switch' === message['body']['request']) {
+    return this.onSwitch(message);
+  }
+
   return PluginVideo.super_.prototype.processMessage.call(this, message);
 };
 
@@ -36,6 +40,24 @@ PluginVideo.prototype.onWatch = function(message) {
     if (plugin._isSuccessResponse(response)) {
       plugin.stream = Stream.generate(message['body']['id'], plugin);
       serviceLocator.get('logger').info('Added ' + plugin.stream + ' for ' + plugin);
+    }
+    return Promise.resolve(response);
+  });
+  return Promise.resolve(message);
+};
+
+/**
+ * @param {Object} message
+ * @returns {Promise}
+ */
+PluginVideo.prototype.onSwitch = function(message) {
+  var plugin = this;
+  plugin.removeStream();
+  plugin.stream = Stream.generate(message['body']['id'], plugin);
+  serviceLocator.get('logger').info('Added ' + plugin.stream + ' for ' + plugin);
+  plugin.session.connection.transactions.add(message['transaction'], function(response) {
+    if (plugin._isSuccessResponse(response)) {
+      return plugin.onWebrtcup(response);
     }
     return Promise.resolve(response);
   });

--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -58,8 +58,9 @@ PluginVideo.prototype.onSwitch = function(message) {
   plugin.session.connection.transactions.add(message['transaction'], function(response) {
     if (plugin._isSuccessResponse(response)) {
       return plugin.onWebrtcup(response);
+    } else {
+      return Promise.resolve(response);
     }
-    return Promise.resolve(response);
   });
   return Promise.resolve(message);
 };

--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -57,7 +57,7 @@ PluginVideo.prototype.onSwitch = function(message) {
   serviceLocator.get('logger').info('Added ' + plugin.stream + ' for ' + plugin);
   plugin.session.connection.transactions.add(message['transaction'], function(response) {
     if (plugin._isSuccessResponse(response)) {
-      return plugin.onWebrtcup(response);
+      return plugin.subscribe(response);
     } else {
       return Promise.resolve(response);
     }

--- a/test/spec/janus/plugin/video.js
+++ b/test/spec/janus/plugin/video.js
@@ -151,8 +151,7 @@ describe('Video plugin', function() {
     sinon.stub(cmApiClient, 'subscribe', function() {
       return Promise.resolve();
     });
-    streams.has.restore();
-    sinon.stub(streams, 'has').returns(true);
+    streams.has.returns(true);
 
     var switchRequest = {
       janus: 'message',


### PR DESCRIPTION
https://github.com/cargomedia/sk/blob/master/library/VR/client-vendor/after-body-source/vr/janus/plugin/video.js

Intercept `switch` event:
- remove previous stream (and store new one) on incoming client message
- subscribe new stream on janus response