### PR TITLE
Error message should refer to a transaction

### DIFF
--- a/lib/janus/error.js
+++ b/lib/janus/error.js
@@ -22,14 +22,17 @@ function JanusError(message, code, transaction) {
 util.inherits(JanusError, Error);
 
 JanusError.prototype.getWebSocketMessage = function() {
-  return {
+  var message = {
     janus: 'error',
-    transaction: this.transaction,
     error: {
       code: this.code || 490,
       reason: this.message
     }
   };
+  if (this.transaction) {
+    message.transaction = this.transaction;
+  }
+  return message;
 };
 
 function WarningError(message, code, transaction) {

--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -69,7 +69,8 @@ PluginStreaming.prototype.subscribe = function(message) {
     })
     .catch(function(error) {
       serviceLocator.get('http-client').detach(plugin);
-      throw new JanusError.Error('Cannot subscribe: ' + plugin.stream + ' error: ' + error.message, 490, message['transaction']);
+      var transaction = message['transaction'] || require('../connection').generateTransactionId();
+      throw new JanusError.Error('Cannot subscribe: ' + plugin.stream + ' error: ' + error.message, 490, transaction);
     });
 };
 

--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -69,8 +69,7 @@ PluginStreaming.prototype.subscribe = function(message) {
     })
     .catch(function(error) {
       serviceLocator.get('http-client').detach(plugin);
-      var transaction = message['transaction'] || require('../connection').generateTransactionId();
-      throw new JanusError.Error('Cannot subscribe: ' + plugin.stream + ' error: ' + error.message, 490, transaction);
+      throw new JanusError.Error('Cannot subscribe: ' + plugin.stream + ' error: ' + error.message, 490, message['transaction']);
     });
 };
 

--- a/test/spec/janus/plugin/streaming.js
+++ b/test/spec/janus/plugin/streaming.js
@@ -183,7 +183,6 @@ describe('PluginStreaming', function() {
         }, function(error) {
           expect(httpClient.detach.callCount).to.be.equal(1);
           expect(error.stack).to.include('error: Cannot subscribe');
-          expect(error.transaction).to.exist;
           done();
         });
       });

--- a/test/spec/janus/plugin/streaming.js
+++ b/test/spec/janus/plugin/streaming.js
@@ -139,8 +139,7 @@ describe('PluginStreaming', function() {
       plugin.stream = new Stream('stream-id', 'channel-name', plugin);
       processWebrtcupMessage = function() {
         return plugin.processMessage({
-          janus: 'webrtcup',
-          transaction: 'transaction-id'
+          janus: 'webrtcup'
         });
       };
 
@@ -184,6 +183,7 @@ describe('PluginStreaming', function() {
         }, function(error) {
           expect(httpClient.detach.callCount).to.be.equal(1);
           expect(error.stack).to.include('error: Cannot subscribe');
+          expect(error.transaction).to.exist;
           done();
         });
       });


### PR DESCRIPTION
The vendor janus client [only call `onmessage` when the `transaction` id is set](https://github.com/cargomedia/sk/blob/master/library/VR/client-vendor/after-body/04-janus/janus.js#L326), but cm-janus specific error have no reference to a transaction, for example:

```
{"janus":"error","error":{"code":490,"reason":"Cannot subscribe: Stream{\"id\":\"049626f1-7909-4e52-af74-d60c00f41e95\"} error: cm-api error: CM_Exception_NotAllowed. Internal server error"}}
{"janus":"error","transaction":"9KuoI217vK2O","error":{"code":490,"reason":"Invalid plugin"}}
```

2 solutions:
- cm-janus send a valid message, with the transaction id
- change the vendor client source code to call the `janus.error` callback if there's no transaction id

related to cargomedia/sk#2507

@njam fyi
