### PR TITLE
Verify if cleanup is done when "mountpoint" is destroyed

### DIFF
--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -33,7 +33,7 @@ PluginVideo.prototype.processMessage = function(message) {
     return this.onSwitch(message);
   }
 
-  if ('event' === janusMessage && 'streaming' === message['plugindata']['data']['streaming'] && 'stopped' === message['plugindata']['data']['result']['status']) {
+  if ('event' === janusMessage && 'event' === message['plugindata']['data']['streaming'] && 'stopped' === message['plugindata']['data']['result']['status']) {
     return this.onStopped(message);
   }
 

--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -125,9 +125,6 @@ PluginVideo.prototype.onSwitch = function(message) {
  * @returns {Promise}
  */
 PluginVideo.prototype.onStopped = function(message) {
-  if (this.channel) {
-    this.removeChannel();
-  }
   this.removeStream();
   return Promise.resolve(message);
 };

--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -19,27 +19,27 @@ PluginVideo.TYPE = 'janus.plugin.cm.rtpbroadcast';
  * @returns {Promise}
  */
 PluginVideo.prototype.processMessage = function(message) {
-  var janusMessage = message['janus'];
-
-  if ('message' === janusMessage && 'create' === message['body']['request']) {
-    return this.onCreate(message);
-  }
-
-  if ('message' === janusMessage && 'watch' === message['body']['request']) {
-    return this.onWatch(message);
-  }
-
-  if ('message' === janusMessage && 'switch' === message['body']['request']) {
-    return this.onSwitch(message);
-  }
-
-  if ('event' === janusMessage && _.isEqual(message['plugindata']['data'], {
-      streaming: 'event',
-      result: {
-        status: 'stopped'
+  switch (message['janus']) {
+    case 'message':
+      switch (message['body']['request']) {
+        case 'create':
+          return this.onCreate(message);
+        case 'watch':
+          return this.onWatch(message);
+        case 'switch':
+          return this.onSwitch(message);
       }
-    })) {
-    return this.onStopped(message);
+      break;
+    case 'event':
+      if (_.isEqual(message['plugindata']['data'], {
+          streaming: 'event',
+          result: {
+            status: 'stopped'
+          }
+        })) {
+        return this.onStopped(message);
+      }
+      break;
   }
 
   return PluginVideo.super_.prototype.processMessage.call(this, message);

--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -33,6 +33,10 @@ PluginVideo.prototype.processMessage = function(message) {
     return this.onSwitch(message);
   }
 
+  if ('event' === janusMessage && 'streaming' === message['plugindata']['data']['streaming'] && 'stopped' === message['plugindata']['data']['result']['status']) {
+    return this.onStopped(message);
+  }
+
   return PluginVideo.super_.prototype.processMessage.call(this, message);
 };
 
@@ -109,6 +113,17 @@ PluginVideo.prototype.onSwitch = function(message) {
     }
   });
   return Promise.resolve(message);
+};
+
+/**
+ * @param {Object} message
+ * @returns {Promise}
+ */
+PluginVideo.prototype.onStopped = function(message) {
+  if (this.channel) {
+    this.removeChannel();
+  }
+  this.removeStream();
 };
 
 module.exports = PluginVideo;

--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -33,7 +33,12 @@ PluginVideo.prototype.processMessage = function(message) {
     return this.onSwitch(message);
   }
 
-  if ('event' === janusMessage && 'event' === message['plugindata']['data']['streaming'] && 'stopped' === message['plugindata']['data']['result']['status']) {
+  if ('event' === janusMessage && _.isEqual(message['plugindata']['data'], {
+      streaming: 'event',
+      result: {
+        status: 'stopped'
+      }
+    })) {
     return this.onStopped(message);
   }
 

--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -129,6 +129,7 @@ PluginVideo.prototype.onStopped = function(message) {
     this.removeChannel();
   }
   this.removeStream();
+  return Promise.resolve(message);
 };
 
 module.exports = PluginVideo;


### PR DESCRIPTION
@tomaszdurka @vogdb @njam

We should make sure that `cm-janus` is aware of `mountpoint` destroy event. If `mountpoint` is destroyed of any reason e.g. master session expires then Janus removes `mountpoint` and notify all connected sessions to the `rtpbroadcast` plugin. It sends following messages:

```
{
   "janus": "event",
   "session_id": 1734302109,
   "sender": 2805623492,
   "plugindata": {
      "plugin": "janus.plugin.cm.rtpbroadcast",
      "data": {
         "streaming": "event",
         "result": {
            "status": "stopped"
         }
      }
   }
}
```
and
```
{
   "janus": "hangup",
   "session_id": 1734302109,
   "sender": 2805623492,
   "reason": "DTLS alert"
}
```

We should make sure to remove `stream` in `CM` then with e.g. `rpc_removeStream`?

@tomaszdurka can you confirm it is implemented?