### PR TITLE
Verify if cleanup is done when "audioroom" is destroyed

### DIFF
--- a/lib/janus/plugin/audio.js
+++ b/lib/janus/plugin/audio.js
@@ -18,17 +18,22 @@ PluginAudio.TYPE = 'janus.plugin.cm.audioroom';
  * @returns {Promise}
  */
 PluginAudio.prototype.processMessage = function(message) {
-  var janusMessage = message['janus'];
-
-  if ('message' === janusMessage) {
-    switch (message['body']['request']) {
-      case 'create':
-        return this.onCreate(message);
-      case 'join':
-        return this.onJoin(message);
-      case 'changeroom':
-        return this.onChangeroom(message);
-    }
+  switch (message['janus']) {
+    case 'message':
+      switch (message['body']['request']) {
+        case 'create':
+          return this.onCreate(message);
+        case 'join':
+          return this.onJoin(message);
+        case 'changeroom':
+          return this.onChangeroom(message);
+      }
+      break;
+    case 'event':
+      if (_.isMatch(message['plugindata']['data'], {audioroom: 'destroyed'})) {
+        return this.onDestroyed(message);
+      }
+      break;
   }
 
   return PluginAudio.super_.prototype.processMessage.call(this, message);
@@ -93,6 +98,13 @@ PluginAudio.prototype.onChangeroom = function(message) {
     return Promise.resolve(response);
   });
   return Promise.resolve(message);
+};
+
+/**
+ * @param {Object} message
+ * @returns {Promise}
+ */
+PluginAudio.prototype.onDestroyed = function(message) {
 };
 
 module.exports = PluginAudio;

--- a/lib/janus/plugin/audio.js
+++ b/lib/janus/plugin/audio.js
@@ -105,6 +105,11 @@ PluginAudio.prototype.onChangeroom = function(message) {
  * @returns {Promise}
  */
 PluginAudio.prototype.onDestroyed = function(message) {
+  if (this.channel) {
+    this.removeChannel();
+  }
+  this.removeStream();
+  return Promise.resolve(message);
 };
 
 module.exports = PluginAudio;

--- a/lib/janus/plugin/audio.js
+++ b/lib/janus/plugin/audio.js
@@ -20,16 +20,15 @@ PluginAudio.TYPE = 'janus.plugin.cm.audioroom';
 PluginAudio.prototype.processMessage = function(message) {
   var janusMessage = message['janus'];
 
-  if ('message' === janusMessage && 'create' === message['body']['request']) {
-    return this.onCreate(message);
-  }
-
-  if ('message' === janusMessage && 'join' === message['body']['request']) {
-    return this.onJoin(message);
-  }
-
-  if ('message' === janusMessage && 'changeroom' === message['body']['request']) {
-    return this.onChangeroom(message);
+  if ('message' === janusMessage) {
+    switch (message['body']['request']) {
+      case 'create':
+        return this.onCreate(message);
+      case 'join':
+        return this.onJoin(message);
+      case 'changeroom':
+        return this.onChangeroom(message);
+    }
   }
 
   return PluginAudio.super_.prototype.processMessage.call(this, message);

--- a/test/spec/janus/plugin/audio.js
+++ b/test/spec/janus/plugin/audio.js
@@ -299,7 +299,6 @@ describe('Audio plugin', function() {
     var destroyedRequest = {
       janus: 'event',
       plugindata: {
-        plugin: 'janus.plugin.cm.audioroom',
         data: {
           audioroom: 'destroyed'
         }
@@ -312,7 +311,6 @@ describe('Audio plugin', function() {
     plugin.processMessage(destroyedRequest).then(function() {
       expect(streams.remove.calledWith(stream)).to.be.equal(true);
       expect(channels.remove.calledWith(channel)).to.be.equal(true);
-      channels.remove.restore();
       done();
     });
   });

--- a/test/spec/janus/plugin/audio.js
+++ b/test/spec/janus/plugin/audio.js
@@ -164,6 +164,25 @@ describe('Audio plugin', function() {
     assert(onChangeroomStub.calledWith(changeroomRequest));
   });
 
+  it('when processes "destroyed" message.', function() {
+    var onDestroyedStub = sinon.stub(plugin, 'onDestroyed', function() {
+      return Promise.resolve();
+    });
+    var destroyedRequest = {
+      janus: 'event',
+      plugindata: {
+        plugin: 'janus.plugin.cm.audioroom',
+        data: {
+          audioroom: 'destroyed'
+        }
+      }
+    };
+    plugin.processMessage(destroyedRequest);
+
+    assert(onDestroyedStub.calledOnce);
+    assert(onDestroyedStub.calledWith(destroyedRequest));
+  });
+
   it('join room', function(done) {
     var joinRequest = {
       janus: 'message',
@@ -270,6 +289,34 @@ describe('Audio plugin', function() {
         expect(streams.add.called).to.be.equal(false);
         done();
       });
+    });
+  });
+
+  it.only('destroy room', function(done) {
+    streams.has.returns(true);
+    sinon.stub(channels, 'remove', function() {
+    });
+    sinon.stub(channels, 'contains', function() {
+      return true;
+    });
+    var destroyedRequest = {
+      janus: 'event',
+      plugindata: {
+        plugin: 'janus.plugin.cm.audioroom',
+        data: {
+          audioroom: 'destroyed'
+        }
+      }
+    };
+    var channel = {};
+    var stream = {channel: channel};
+    plugin.stream = stream;
+    plugin.channel = channel;
+    plugin.processMessage(destroyedRequest).then(function() {
+      expect(streams.remove.calledWith(stream)).to.be.equal(true);
+      expect(channels.remove.calledWith(channel)).to.be.equal(true);
+      channels.remove.restore();
+      done();
     });
   });
 

--- a/test/spec/janus/plugin/audio.js
+++ b/test/spec/janus/plugin/audio.js
@@ -34,7 +34,8 @@ describe('Audio plugin', function() {
     serviceLocator.register('cm-api-client', cmApiClient);
     streams = sinon.createStubInstance(Streams);
     serviceLocator.register('streams', streams);
-    channels = new Channels;
+    channels = sinon.createStubInstance(Channels);
+    channels.getByNameAndData.restore();
     sinon.stub(channels, 'getByNameAndData', function(name, data) {
       return Channel.generate(name, data);
     });
@@ -292,13 +293,9 @@ describe('Audio plugin', function() {
     });
   });
 
-  it.only('destroy room', function(done) {
+  it('destroy room', function(done) {
     streams.has.returns(true);
-    sinon.stub(channels, 'remove', function() {
-    });
-    sinon.stub(channels, 'contains', function() {
-      return true;
-    });
+    channels.contains.returns(true);
     var destroyedRequest = {
       janus: 'event',
       plugindata: {


### PR DESCRIPTION
@tomaszdurka @vogdb @njam 

We should make sure that `cm-janus` is aware of room destroy event. If room is destroyed of any reason e.g. master session expires then Janus removes room and notify all connected sessions to the audioroom plugin. It sends something like this:
```
{
   "janus": "event",
   "session_id": 1389549831,
   "sender": 2462998037,
   "plugindata": {
      "plugin": "janus.plugin.cm.audioroom",
      "data": {
         "audioroom": "destroyed",
         "id": "1234"
      }
   }
}
``` 

We should make sure to remove `stream` in `CM` then with e.g. `rpc_removeStream`?

@tomaszdurka can you confirm it is implemented?