### PR TITLE
Destroy session on "timeout"

### DIFF
--- a/lib/janus/connection.js
+++ b/lib/janus/connection.js
@@ -44,6 +44,9 @@ JanusConnection.prototype.processMessage = function(message) {
   if ('destroy' === janusMessage) {
     return this.onDestroy(message);
   }
+  if ('timeout' === janusMessage) {
+    return this.onTimeout(message);
+  }
 
   var sessionId = message['session_id'] || null;
   if (sessionId) {
@@ -87,6 +90,15 @@ JanusConnection.prototype.onDestroy = function(message) {
     this._removeSession();
     return Promise.resolve(response);
   }.bind(this));
+  return Promise.resolve(message);
+};
+
+/**
+ * @param {Object} message
+ * @returns {Promise}
+ */
+JanusConnection.prototype.onTimeout = function(message) {
+  this._removeSession();
   return Promise.resolve(message);
 };
 

--- a/test/spec/janus/connection.js
+++ b/test/spec/janus/connection.js
@@ -119,6 +119,21 @@ describe('JanusConnection', function() {
     });
   });
 
+  context('when processes "timeout" message"', function() {
+    beforeEach(function() {
+      var message = {
+        janus: 'timeout',
+        sessionId: 'session-id'
+      };
+      connection.session = sinon.createStubInstance(Session);
+      connection.processMessage(message);
+    });
+
+    it('should remove session', function() {
+      expect(connection.session).to.be.equal(null);
+    });
+  });
+
   context('when processes session-related message', function() {
     var message = {
       janus: 'event',


### PR DESCRIPTION
@tomaszdurka @vogdb 

Example message from janus:
```
app debug <- janus {"janus":"timeout","session_id":1610821549}
```