### PR TITLE
Add support for transparent "audioroom" create on join/changeroom

### DIFF
--- a/lib/channels.js
+++ b/lib/channels.js
@@ -38,11 +38,10 @@ Channels.prototype.findByName = function(name) {
 /**
  * @param {String} name
  * @param {String} data
+ * @returns {Channel}
  */
 Channels.prototype.getByNameAndData = function(name, data) {
-  var channel = _.find(this.list, function(channel) {
-    return channel.name === name && channel.data === data;
-  });
+  var channel = this.findByNameAndData(name, data);
   if (!channel) {
     var invalidDataChannel = this.findByName(name);
     if (invalidDataChannel) {
@@ -52,6 +51,17 @@ Channels.prototype.getByNameAndData = function(name, data) {
     }
   }
   return channel;
+};
+
+/**
+ * @param {String} name
+ * @param {String} data
+ * @returns {Channel|null}
+ */
+Channels.prototype.findByNameAndData = function(name, data) {
+  return _.find(this.list, function(channel) {
+    return channel.name === name && channel.data === data;
+  });
 };
 
 /**

--- a/lib/janus/plugin/audio.js
+++ b/lib/janus/plugin/audio.js
@@ -68,7 +68,7 @@ PluginAudio.prototype.onJoin = function(message) {
   var plugin = this;
   plugin.session.connection.transactions.add(message['transaction'], function(response) {
     if (plugin._isSuccessResponse(response) && 'joined' == response['plugindata']['data']['audioroom']) {
-      var channel = serviceLocator.get('channels').getByNameAndData(message['body']['id'], message['body']['channel_data']);
+      var channel = plugin.getChannel(message['body']['id'], message['body']['channel_data']);
       plugin.stream = Stream.generate(channel, plugin);
       serviceLocator.get('logger').info('Added ' + plugin.stream + ' for ' + plugin);
     }
@@ -84,7 +84,7 @@ PluginAudio.prototype.onJoin = function(message) {
 PluginAudio.prototype.onChangeroom = function(message) {
   var plugin = this;
   plugin.removeStream();
-  var channel = serviceLocator.get('channels').getByNameAndData(message['body']['id'], message['body']['channel_data']);
+  var channel = plugin.getChannel(message['body']['id'], message['body']['channel_data']);
   plugin.stream = Stream.generate(channel, plugin);
   serviceLocator.get('logger').info('Added ' + plugin.stream + ' for ' + plugin);
   plugin.session.connection.transactions.add(message['transaction'], function(response) {
@@ -94,6 +94,21 @@ PluginAudio.prototype.onChangeroom = function(message) {
     return Promise.resolve(response);
   });
   return Promise.resolve(message);
+};
+
+/**
+ * @param {String} name
+ * @param {String} data
+ * @returns {Channel}
+ */
+PluginAudio.prototype.getChannel = function(name, data) {
+  var channels = serviceLocator.get('channels');
+  var channel = channels.findByNameAndData(name, data);
+  if (!channel) {
+    channel = Channel.generate(name, data);
+    channels.add(channel);
+  }
+  return channel;
 };
 
 module.exports = PluginAudio;


### PR DESCRIPTION
We have added support for transparent `audioroom` creation if `room` does not exist on `join/changeroom` request. It is done here https://github.com/cargomedia/janus-gateway-audioroom/pull/27 and support for
> 
- Rooms should created transparently. If a room doesn't exist on "join" and "changeroom" it would be created
- There should be no more "master" connection - i.e. the room is not destroyed when the "master" disconnects
- When the last user leaves the room it is destroyed.

@tomaszdurka @vogdb we get this error currently
```
app debug <- janus {"janus":"event","session_id":1889884226,"sender":1787354233,"transaction":"Cc2AXggJAZ24","plugindata":{"plugin":"janus.plugin.cm.audioroom","data":{"audioroom":"joined","id":"nNOeUH4Q6aIvVjdTfYexlQ__","userid":397326083,"participants":[{"userid":1740950939,"display":"7kky1glow29","muted":"false"},{"userid":1867017612,"display":"cnuibpgb9","muted":"false"}]}}}
app error Error: Channel with name `nNOeUH4Q6aIvVjdTfYexlQ__` and data `{"streamChannelType":270}` not found.
    at Channels.getByNameAndData (/usr/lib/node_modules/cm-janus/lib/channels.js:51:13)
    at /usr/lib/node_modules/cm-janus/lib/janus/plugin/audio.js:71:52
    at Transactions.execute (/usr/lib/node_modules/cm-janus/lib/janus/transactions.js:53:26)
    at JanusConnection.processMessage (/usr/lib/node_modules/cm-janus/lib/janus/connection.js:36:32)
    at Connection.<anonymous> (/usr/lib/node_modules/cm-janus/lib/janus/proxy.js:75:16)
    at Connection.emit (events.js:107:17)
    at Connection._onMessage (/usr/lib/node_modules/cm-janus/lib/connection.js:97:10)
    at Connection.<anonymous> (/usr/lib/node_modules/cm-janus/lib/connection.js:21:10)
    at WebSocket.emit (events.js:110:17)
    at Receiver.ontext (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/WebSocket.js:816:10)
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:477:18
    at Receiver.applyExtensions (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:364:5)
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:466:14
    at Receiver.flush (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:340:3)
    at Receiver.opcodes.1.finish (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:482:12)
    at Receiver.expectHandler (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:457:31)
    at Receiver.add (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:95:24)
    at Socket.realHandler (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/WebSocket.js:800:20)
    at Socket.emit (events.js:107:17)
    at readableAddChunk (_stream_readable.js:163:16)
    at Socket.Readable.push (_stream_readable.js:126:10)
    at TCP.onread (net.js:540:20)
```

which makes sense because cm-janus does not expect this behaviour?

cc @njam 