### PR TITLE
Adjust configuration information about handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,12 @@ cmApplication:
 jobManager:
   jobsPath: '/tmp/jobs' # place where job definitions are stored
   tempFilesPath: '/tmp/jobs/temp-files/' # jobs handlers' temp files
+  handlersConfiguration: # configuration of jobs handlers. Names in `<%= %>` delimiters are placeholders for commands arguments.
+    'janus.plugin.cm.audioroom:audio-recording-finished': # audio recording job handler
+      convertCommand: 'lame <%= wavFile %> <%= mp3File %>' # a command to use for audio recording.
+    'janus.plugin.cm.rtpbroadcast:recording-finished': # video recording job handler
+      mergeCommand: 'mjr2webm <%= videoMjrFile %> <%= audioMjrFile %> <%= webmFile %>' # a command to use for video recording.
+    'janus.plugin.cm.rtpbroadcast:thumbnailing-finished': # video thumbnail job handler
+      createThumbnailCommand: 'mjr2png <%= videoMjrFile %> <%= width %> <%= height %> <%= pngFile %>' # a command to use for thumbnailing video.
 ```
 

--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -19,6 +19,6 @@ jobManager:
     'janus.plugin.cm.audioroom:audio-recording-finished':
       convertCommand: 'lame <%= wavFile %> <%= mp3File %>'
     'janus.plugin.cm.rtpbroadcast:recording-finished':
-      mergeCommand: 'mjr2webm <%= audioMjrFile %> <%= videoMjrFile %> <%= webmFile %>'
+      mergeCommand: 'mjr2webm <%= videoMjrFile %> <%= audioMjrFile %> <%= webmFile %>'
     'janus.plugin.cm.rtpbroadcast:thumbnailing-finished':
       createThumbnailCommand: 'mjr2png <%= videoMjrFile %> <%= width %> <%= height %> <%= pngFile %>'


### PR DESCRIPTION
- add handlers to docu
- adjust default config to use correct mjr2webm notation (swap audio/video arguments to: `mjr2webm <%= videoMjrFile %> <%= audioMjrFile %> <%= webmFile %>`)