### PR TITLE
Failing RPC call closes connection?

### DIFF
--- a/lib/cm-api-client.js
+++ b/lib/cm-api-client.js
@@ -1,5 +1,6 @@
 var serviceLocator = require('./service-locator');
 var requestPromise = require('request-promise');
+var JanusError = require('./janus/error');
 
 /**
  * @param {String} baseUrl
@@ -38,7 +39,7 @@ CMApiClient.prototype._request = function(action, data) {
   serviceLocator.get('logger').info('cm-api', 'request', options.uri, options.body);
   return this._requestPromise(options)
     .catch(function(error) {
-      throw new Error('cm-api error: ' + error['message']);
+      throw new JanusError.Warning('cm-api error: ' + error['message']);
     })
     .then(function(response) {
       var error = response['error'];


### PR DESCRIPTION
```
app error Error: cm-api error: 500 - <h1>Exception</h1><h2>test</h2><pre>/home/vagrant/sk/vendor/cargomedia/cm/library/CM/Janus/RpcEndpoints.php on line 69</pre><pre>    0. {main} /home/vagrant/sk/public/index.php:0
    1. CM_Http_Handler->processRequest(CM_Http_Request_Post) /home/vagrant/sk/public/index.php:8
    2. CM_Http_Response_Abstract->process() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Handler.php:26
    3. CM_Http_Response_RPC->_process() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php:47
    4. CM_Http_Response_Abstract->_runWithCatching(Closure, Closure) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Response/RPC.php:21
    5. CM_Http_Response_RPC->{closure}() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php:257
    6. call_user_func_array([], []) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Response/RPC.php:18
    7. [internal function] 
</pre>

    at /usr/lib/node_modules/cm-janus/lib/cm-api-client.js:41:13
    at tryCatcher (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromises (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:697:14)
    at Async._drainQueue (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:367:17)
app info cm-api request https://alicex.dev.cargomedia.ch/rpc/null {"method":"CM_Janus_RpcEndpoints.removeStream","params":["mad-panda","-yfrrV7oRpqwXg74oe.6Pg__","c449f0e8-56c3-45bc-9cb8-3f309c0fefce"]}
app info Removed Plugin{"id":2953772987,"type":"janus.plugin.cm.rtpbroadcast"}
app info cm-api request https://alicex.dev.cargomedia.ch/rpc/null {"method":"CM_Janus_RpcEndpoints.removeStream","params":["mad-panda","uU7XW0UBSd9vDFUQtZ3Sow__","98438d74-7600-422e-9e4b-30ab2e63c821"]}
app info Removed Plugin{"id":3619147809,"type":"janus.plugin.cm.audioroom"}
app info Removed Session{"id":551824903}
app info Removed Connection{"id":"d61f007a-2318-4cf1-97e9-90331b10cf50"}
```