### PR TITLE
Timeout issue: Cannot read property 'onRemove' of null

### DIFF
--- a/lib/janus/connection.js
+++ b/lib/janus/connection.js
@@ -103,15 +103,15 @@ JanusConnection.prototype.onTimeout = function(message) {
 };
 
 JanusConnection.prototype.onRemove = function() {
-  if (null !== this.session) {
-    this._removeSession();
-  }
+  this._removeSession();
   serviceLocator.get('logger').info('Removed ' + this);
 };
 
 JanusConnection.prototype._removeSession = function() {
-  this.session.onRemove();
-  this.session = null;
+  if (null !== this.session) {
+    this.session.onRemove();
+    this.session = null;
+  }
 };
 
 /**


### PR DESCRIPTION
```
app debug <- janus {"janus":"timeout","session_id":229926117}
app error TypeError: Cannot read property 'onRemove' of null
    at JanusConnection._removeSession (/usr/lib/node_modules/cm-janus/lib/janus/connection.js:113:15)
    at JanusConnection.onTimeout (/usr/lib/node_modules/cm-janus/lib/janus/connection.js:101:8)
    at JanusConnection.processMessage (/usr/lib/node_modules/cm-janus/lib/janus/connection.js:48:17)
    at Connection.<anonymous> (/usr/lib/node_modules/cm-janus/lib/janus/proxy.js:75:16)
    at Connection.emit (events.js:107:17)
    at Connection._onMessage (/usr/lib/node_modules/cm-janus/lib/connection.js:97:10)
    at Connection.<anonymous> (/usr/lib/node_modules/cm-janus/lib/connection.js:21:10)
    at WebSocket.emit (events.js:110:17)
    at Receiver.ontext (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/WebSocket.js:816:10)
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:477:18
    at Receiver.applyExtensions (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:364:5)
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:466:14
    at Receiver.flush (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:340:3)
    at Receiver.opcodes.1.finish (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:482:12)
    at Receiver.expectHandler (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:457:31)
    at Receiver.add (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:95:24)
    at Socket.realHandler (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/WebSocket.js:800:20)
    at Socket.emit (events.js:107:17)
    at readableAddChunk (_stream_readable.js:163:16)
    at Socket.Readable.push (_stream_readable.js:126:10)
    at TCP.onread (net.js:540:20)
```