### PR TITLE
Do not treat web-socket write exceptions as errors

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -62,7 +62,7 @@ Connection.prototype.isOpened = function() {
  */
 Connection.prototype._queue = function(message) {
   var self = this;
-  return new Promise(function(resolve, reject) {
+  return new Promise(function(resolve) {
     self.webSocket.once('open', function() {
       self._send(message).then(function(response) {
         resolve(response);
@@ -82,8 +82,9 @@ Connection.prototype._send = function(message) {
     this.webSocket.send(JSON.stringify(message), {}, function(err) {
       if (err) {
         reject(err);
+      } else {
+        resolve();
       }
-      resolve();
     });
   }.bind(this));
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -78,15 +78,14 @@ Connection.prototype._queue = function(message) {
  */
 Connection.prototype._send = function(message) {
   serviceLocator.get('logger').debug('-> ' + this.identifier, message);
-  var self = this;
-  return new Promise(function(resolve) {
-    self.webSocket.send(JSON.stringify(message), {}, function(err) {
+  return new Promise(function(resolve, reject) {
+    this.webSocket.send(JSON.stringify(message), {}, function(err) {
       if (err) {
-        serviceLocator.get('logger').debug('-> ' + self.identifier, 'websocket send error', err);
+        reject(err);
       }
       resolve();
     });
-  });
+  }.bind(this));
 };
 
 /**

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -78,14 +78,15 @@ Connection.prototype._queue = function(message) {
  */
 Connection.prototype._send = function(message) {
   serviceLocator.get('logger').debug('-> ' + this.identifier, message);
-  return new Promise(function(resolve, reject) {
-    this.webSocket.send(JSON.stringify(message), {}, function(err) {
+  var self = this;
+  return new Promise(function(resolve) {
+    self.webSocket.send(JSON.stringify(message), {}, function(err) {
       if (err) {
-        reject(err);
+        serviceLocator.get('logger').debug('-> ' + self.identifier, 'websocket send error', err);
       }
       resolve();
     });
-  }.bind(this));
+  });
 };
 
 /**

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -78,11 +78,8 @@ Connection.prototype._queue = function(message) {
  */
 Connection.prototype._send = function(message) {
   serviceLocator.get('logger').debug('-> ' + this.identifier, message);
-  return new Promise(function(resolve, reject) {
-    this.webSocket.send(JSON.stringify(message), {}, function(err) {
-      if (err) {
-        reject(err);
-      }
+  return new Promise(function(resolve) {
+    this.webSocket.send(JSON.stringify(message), {}, function() {
       resolve();
     });
   }.bind(this));

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -78,8 +78,11 @@ Connection.prototype._queue = function(message) {
  */
 Connection.prototype._send = function(message) {
   serviceLocator.get('logger').debug('-> ' + this.identifier, message);
-  return new Promise(function(resolve) {
-    this.webSocket.send(JSON.stringify(message), {}, function() {
+  return new Promise(function(resolve, reject) {
+    this.webSocket.send(JSON.stringify(message), {}, function(err) {
+      if (err) {
+        reject(err);
+      }
       resolve();
     });
   }.bind(this));

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -66,15 +66,19 @@ JanusProxy.prototype.establishConnection = function(fromClientConnection, toJanu
   };
 
   fromClientConnection.on('message', function(request) {
-    connection.processMessage(request).then(function(processedRequest) {
-      toJanusConnection.send(processedRequest);
-    }, handleError);
+    connection.processMessage(request)
+      .then(function(processedRequest) {
+        toJanusConnection.send(processedRequest);
+      })
+      .catch(handleError);
   });
 
   toJanusConnection.on('message', function(request) {
-    connection.processMessage(request).then(function(processedRequest) {
-      fromClientConnection.send(processedRequest);
-    }, handleError);
+    connection.processMessage(request)
+      .then(function(processedRequest) {
+        fromClientConnection.send(processedRequest);
+      })
+      .catch(handleError);
   });
 
   fromClientConnection.on('close', function() {

--- a/test/spec/janus/proxy.js
+++ b/test/spec/janus/proxy.js
@@ -89,10 +89,12 @@ describe('JanusProxy', function() {
 
         it('should be handled as error', function(done) {
           fromClientConnection.emit('message', 'body');
-          connection.processMessage.firstCall.returnValue.catch(function() {
-            expect(proxy.handleError.withArgs('error-instance').calledOnce).to.be.equal(true);
-            done();
-          })
+          setTimeout(function() {
+            connection.processMessage.firstCall.returnValue.catch(function() {
+              expect(proxy.handleError.withArgs('error-instance').calledOnce).to.be.equal(true);
+              done();
+            });
+          }, 0);
         });
       });
     });
@@ -128,10 +130,12 @@ describe('JanusProxy', function() {
 
         it('should be handled as error', function(done) {
           toJanusConnection.emit('message', 'body');
-          connection.processMessage.firstCall.returnValue.catch(function() {
-            expect(proxy.handleError.withArgs('error-instance').calledOnce).to.be.equal(true);
-            done();
-          });
+          setTimeout(function() {
+            connection.processMessage.firstCall.returnValue.catch(function() {
+              expect(proxy.handleError.withArgs('error-instance').calledOnce).to.be.equal(true);
+              done();
+            });
+          }, 0);
         });
       });
     });


### PR DESCRIPTION
```
app error Unexpected rejection error. Error: write after end
    at writeAfterEnd (_stream_writable.js:167:12)
    at Socket.Writable.write (_stream_writable.js:214:5)
    at Socket.write (net.js:636:40)
    at Sender.frameAndSend (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Sender.js:224:22)
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/Sender.js:126:12
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/PerMessageDeflate.js:290:5
    at afterWrite (_stream_writable.js:361:3)
    at onwrite (_stream_writable.js:352:7)
    at WritableState.onwrite (_stream_writable.js:105:5)
    at afterTransform (_stream_transform.js:99:5)
    at TransformState.afterTransform (_stream_transform.js:74:12)
    at Zlib.callback (zlib.js:611:5)
```