### PR TITLE
subscribe: Cannot read property 'plugin' of null

### DIFF
--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -29,7 +29,10 @@ PluginStreaming.prototype.processMessage = function(message) {
  */
 PluginStreaming.prototype.subscribe = function(message) {
   var plugin = this;
-  return serviceLocator.get('cm-api-client').subscribe(plugin.stream)
+  return Promise.resolve(message)
+    .then(function() {
+      return serviceLocator.get('cm-api-client').subscribe(plugin.stream)
+    })
     .then(function() {
       serviceLocator.get('streams').add(plugin.stream);
       serviceLocator.get('logger').info('Storing ' + plugin.stream + ' for ' + plugin);
@@ -47,7 +50,10 @@ PluginStreaming.prototype.subscribe = function(message) {
  */
 PluginStreaming.prototype.publish = function(message) {
   var plugin = this;
-  return serviceLocator.get('cm-api-client').publish(plugin.stream)
+  return Promise.resolve(message)
+    .then(function() {
+      return serviceLocator.get('cm-api-client').publish(plugin.stream)
+    })
     .then(function() {
       serviceLocator.get('streams').add(plugin.stream);
       serviceLocator.get('logger').info('Storing ' + plugin.stream + ' for ' + plugin);

--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -6,6 +6,8 @@ var Promise = require('bluebird');
 
 function PluginStreaming() {
   PluginStreaming.super_.apply(this, arguments);
+
+  /** @type {Stream|null} */
   this.stream = null;
 }
 
@@ -68,6 +70,9 @@ PluginStreaming.prototype.publish = function(message) {
     });
 };
 
+/**
+ * @returns {Stream}
+ */
 PluginStreaming.prototype.getStream = function() {
   if (null === this.stream) {
     throw new JanusError.Warning('No Stream found for ' + this);

--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -30,18 +30,19 @@ PluginStreaming.prototype.processMessage = function(message) {
  */
 PluginStreaming.prototype.subscribe = function(message) {
   var plugin = this;
-  return Promise.resolve(message)
+  return Promise.resolve()
     .then(function() {
-      return serviceLocator.get('cm-api-client').subscribe(plugin.stream)
+      return serviceLocator.get('cm-api-client').subscribe(plugin.getStream())
     })
     .then(function() {
-      serviceLocator.get('streams').add(plugin.stream);
-      serviceLocator.get('logger').info('Storing ' + plugin.stream + ' for ' + plugin);
+      var stream = plugin.getStream();
+      serviceLocator.get('streams').add(stream);
+      serviceLocator.get('logger').info('Storing ' + stream + ' for ' + plugin);
       return message;
     })
     .catch(JanusError.Error, function(error) {
       serviceLocator.get('http-client').detach(plugin);
-      throw new JanusError.Error('Cannot subscribe: ' + plugin.stream + ' error: ' + error.message, 490, message['transaction']);
+      throw new JanusError.Error('Cannot subscribe: ' + plugin.stream + ' for ' + plugin + 'error: ' + error.message, 490, message['transaction']);
     });
 };
 
@@ -51,19 +52,27 @@ PluginStreaming.prototype.subscribe = function(message) {
  */
 PluginStreaming.prototype.publish = function(message) {
   var plugin = this;
-  return Promise.resolve(message)
+  return Promise.resolve()
     .then(function() {
-      return serviceLocator.get('cm-api-client').publish(plugin.stream)
+      return serviceLocator.get('cm-api-client').publish(plugin.getStream())
     })
     .then(function() {
-      serviceLocator.get('streams').add(plugin.stream);
-      serviceLocator.get('logger').info('Storing ' + plugin.stream + ' for ' + plugin);
+      var stream = plugin.getStream();
+      serviceLocator.get('streams').add(stream);
+      serviceLocator.get('logger').info('Storing ' + stream + ' for ' + plugin);
       return message;
     })
     .catch(JanusError.Error, function(error) {
       serviceLocator.get('http-client').detach(plugin);
-      throw new JanusError.Error('Cannot publish: ' + plugin.stream + ' error: ' + error.message, 490, message['transaction']);
+      throw new JanusError.Error('Cannot publish: ' + plugin.stream + ' for ' + plugin + ' error: ' + error.message, 490, message['transaction']);
     });
+};
+
+PluginStreaming.prototype.getStream = function() {
+  if (null === this.stream) {
+    throw new JanusError.Warning('No Stream found for ' + this);
+  }
+  return this.stream;
 };
 
 PluginStreaming.prototype.removeStream = function() {

--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -2,6 +2,7 @@ var util = require('util');
 var PluginAbstract = require('./abstract.js');
 var serviceLocator = require('../../service-locator');
 var JanusError = require('../error');
+var Promise = require('bluebird');
 
 function PluginStreaming() {
   PluginStreaming.super_.apply(this, arguments);


### PR DESCRIPTION
```
app info cm-api request https://alicex.dev.cargomedia.ch/rpc/null {"method":"CM_Janus_RpcEndpoints.publish","params":["mad-panda","{\"sessionId\":\"79d6efc145f1cc79e2d1593b0b6f6c07\"}","WjexdytNPTosH5VkDiq17A__","7b251c823714820365ade577b077674e","{\"streamChannelType\":269}","2c03a7ed-a315-4059-9073-793e8e633547",1453139254.06]}
app info cm-api response 
app info cm-api response 
app debug <- janus {"janus":"webrtcup","session_id":3089257324,"sender":234971487}
app error TypeError: Cannot read property 'plugin' of null
    at CMApiClient.subscribe (/usr/lib/node_modules/cm-janus/lib/cm-api-client.js:75:11)
    at PluginAudio.PluginStreaming.subscribe (/usr/lib/node_modules/cm-janus/lib/janus/plugin/streaming.js:32:46)
    at PluginAudio.PluginStreaming.processMessage (/usr/lib/node_modules/cm-janus/lib/janus/plugin/streaming.js:21:17)
    at PluginAudio.processMessage (/usr/lib/node_modules/cm-janus/lib/janus/plugin/audio.js:37:54)
    at Session.processMessage (/usr/lib/node_modules/cm-janus/lib/janus/session.js:45:21)
    at JanusConnection.processMessage (/usr/lib/node_modules/cm-janus/lib/janus/connection.js:54:27)
    at Connection.<anonymous> (/usr/lib/node_modules/cm-janus/lib/janus/proxy.js:75:16)
    at Connection.emit (events.js:107:17)
    at Connection._onMessage (/usr/lib/node_modules/cm-janus/lib/connection.js:97:10)
    at Connection.<anonymous> (/usr/lib/node_modules/cm-janus/lib/connection.js:21:10)
    at WebSocket.emit (events.js:110:17)
    at Receiver.ontext (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/WebSocket.js:816:10)
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:477:18
    at Receiver.applyExtensions (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:364:5)
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:466:14
    at Receiver.flush (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:340:3)
    at Receiver.opcodes.1.finish (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:482:12)
    at Receiver.expectHandler (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:457:31)
    at Receiver.add (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Receiver.js:95:24)
    at Socket.realHandler (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/WebSocket.js:800:20)
    at Socket.emit (events.js:107:17)
    at readableAddChunk (_stream_readable.js:163:16)
app info Removed Plugin{"id":234971487,"type":"janus.plugin.cm.audioroom"}
app info Removed Plugin{"id":1759275660,"type":"janus.plugin.cm.rtpbroadcast"}
app info Removed Session{"id":3089257324}
app info Removed Connection{"id":"8d6b0a53-d6a8-472e-b6d3-b9d80ffa5f98"}
```
followed by:
```
app error Error: cm-api error: 500 - <h1>CM_Exception_Invalid</h1><h2>Passed stream channel mediaId does not match existing</h2><pre>/home/vagrant/sk/vendor/cargomedia/cm/library/CM/Janus/RpcEndpoints.php on line 43</pre><pre>    0. {main} /home/vagrant/sk/public/index.php:0
    1. CM_Http_Handler->processRequest(CM_Http_Request_Post) /home/vagrant/sk/public/index.php:8
    2. CM_Http_Response_Abstract->process() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Handler.php:26
    3. CM_Http_Response_RPC->_process() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php:47
    4. CM_Http_Response_Abstract->_runWithCatching(Closure, Closure) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Response/RPC.php:21
    5. CM_Http_Response_RPC->{closure}() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php:257
    6. call_user_func_array([], []) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Response/RPC.php:18
    7. [internal function] 
</pre>

    at /usr/lib/node_modules/cm-janus/lib/cm-api-client.js:41:13
    at tryCatcher (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromises (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:697:14)
    at Async._drainQueue (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:367:17)
app info cm-api request https://alicex.dev.cargomedia.ch/rpc/null {"method":"CM_Janus_RpcEndpoints.removeStream","params":["mad-panda","WjexdytNPTosH5VkDiq17A__","2c03a7ed-a315-4059-9073-793e8e633547"]}
app info Removed Plugin{"id":2929453748,"type":"janus.plugin.cm.rtpbroadcast"}

```