### PR TITLE
Pass along thumbnail "createdAt" to cm

### DIFF
--- a/lib/cm-application.js
+++ b/lib/cm-application.js
@@ -15,10 +15,11 @@ function CmApplication(applicationRootPath) {
 /**
  * @param {String} channelUid
  * @param {String} thumbnailPath
+ * @param {Number} createdAt
  * @returns {Promise}
  */
-CmApplication.prototype.importVideoStreamThumbnail = function(channelUid, thumbnailPath) {
-  return this.runCommand('media-streams', 'import-video-thumbnail', [channelUid, thumbnailPath]);
+CmApplication.prototype.importVideoStreamThumbnail = function(channelUid, thumbnailPath, createdAt) {
+  return this.runCommand('media-streams', 'import-video-thumbnail', [channelUid, thumbnailPath, createdAt]);
 };
 
 /**
@@ -40,7 +41,6 @@ CmApplication.prototype.runCommand = function(packageName, action, args) {
   args = args || [];
   var command = ['bin/cm', packageName, action].concat(args).join(' ');
   return new Promise(function(resolve, reject) {
-
     serviceLocator.get('logger').debug('Running cm command `' + command + '`');
     this._exec(command, {cwd: this.applicationRootPath}, function(error) {
       if (error) {

--- a/lib/job/model/rtpbroadcast-thumbnail.js
+++ b/lib/job/model/rtpbroadcast-thumbnail.js
@@ -13,6 +13,9 @@ function RtpbroadcastThumbnailJob(id, jobData, configuration) {
   if (!_.has(jobData, 'uid')) {
     throw new Error('No `uid` parameter provided');
   }
+  if (!_.has(jobData, 'createdAt')) {
+    throw new Error('No `createdAt` parameter provided');
+  }
   RtpbroadcastThumbnailJob.super_.apply(this, arguments);
 }
 
@@ -30,12 +33,13 @@ RtpbroadcastThumbnailJob.prototype._run = function() {
   var self = this;
   var channelUid = this._jobData.uid;
   var videoMjrFile = this._jobData.thumb;
+  var createdAt = this._jobData.createdAt;
 
   return this._tmpFilename('png')
     .then(function(pngFile) {
       return self._extractThumbnail(videoMjrFile, pngFile)
         .then(function() {
-          return serviceLocator.get('cm-application').importVideoStreamThumbnail(channelUid, pngFile)
+          return serviceLocator.get('cm-application').importVideoStreamThumbnail(channelUid, pngFile, createdAt)
         })
         .then(function() {
           var errorHandler = function(error) {

--- a/test/spec/job/model/rtpbroadcast-thumbnail.js
+++ b/test/spec/job/model/rtpbroadcast-thumbnail.js
@@ -38,7 +38,8 @@ describe('RtpbroadcastThumbnailJob', function() {
     before(function(done) {
       var jobData = {
         thumb: 'video-file',
-        uid: 'stream-channel-id'
+        uid: 'stream-channel-id',
+        createdAt: 1453395041
       };
       var configuration = {
         createThumbnailCommand: 'thumbnail <%= videoMjrFile %> -param value <%= pngFile %>'
@@ -66,6 +67,7 @@ describe('RtpbroadcastThumbnailJob', function() {
       assert(cmApplication.importVideoStreamThumbnail.calledOnce, 'importVideoStreamThumbnail was not called');
       assert.equal(cmApplication.importVideoStreamThumbnail.firstCall.args[0], 'stream-channel-id');
       assert.equal(cmApplication.importVideoStreamThumbnail.firstCall.args[1], commandArgs[4]);
+      assert.equal(cmApplication.importVideoStreamThumbnail.firstCall.args[2], 1453395041);
     });
 
   });

--- a/test/unit/cm-application.js
+++ b/test/unit/cm-application.js
@@ -35,8 +35,8 @@ describe('CmApplication', function() {
     var cmApplication = new CmApplication('applicationRootPath');
     var runCommand = sinon.stub(cmApplication, 'runCommand');
     runCommand.returns(Promise.resolve());
-    assert.instanceOf(cmApplication.importVideoStreamThumbnail('streamChannelId', 'thumb'), Promise);
-    assert(runCommand.withArgs('media-streams', 'import-video-thumbnail', ['streamChannelId', 'thumb']).calledOnce);
+    assert.instanceOf(cmApplication.importVideoStreamThumbnail('streamChannelId', 'thumb', 1453395041), Promise);
+    assert(runCommand.withArgs('media-streams', 'import-video-thumbnail', ['streamChannelId', 'thumb', 1453395041]).calledOnce);
 
   });
 


### PR DESCRIPTION
New field "createdAt" (unix timestamp) was added to thumbnail job descriptions:
https://github.com/cargomedia/janus-gateway-rtpbroadcast/pull/57

It will be expected as a new third argument to `importVideoThumbnail` in https://github.com/cargomedia/cm/pull/2065

@tomaszdurka @vogdb can you pass it along accordingly?
Can you check if it's okay to pass superfluous arguments to the CLI call - so that we could merge this here first, and then change it in CM.