### PR TITLE
Remove transaction field from JanusError

### DIFF
--- a/lib/janus/connection.js
+++ b/lib/janus/connection.js
@@ -53,7 +53,7 @@ JanusConnection.prototype.processMessage = function(message) {
     if (this.session !== null && this.session.id === sessionId) {
       return this.session.processMessage(message);
     } else {
-      return Promise.reject(new JanusError.InvalidSession(message['transaction'], sessionId));
+      return Promise.reject(new JanusError.InvalidSession(sessionId));
     }
   }
 
@@ -62,7 +62,7 @@ JanusConnection.prototype.processMessage = function(message) {
     if (this.session && this.session.plugins[pluginId]) {
       return this.session.processMessage(message);
     } else {
-      return Promise.reject(new JanusError.InvalidPlugin(message['transaction'], pluginId));
+      return Promise.reject(new JanusError.InvalidPlugin(pluginId));
     }
   }
 

--- a/lib/janus/error.js
+++ b/lib/janus/error.js
@@ -16,24 +16,6 @@ function JanusError(message, code) {
 }
 util.inherits(JanusError, Error);
 
-/**
- * @param {String} [transaction]
- * @returns {{janus: string, error: {code: (*|number), reason: (String|*)}}}
- */
-JanusError.prototype.getWebSocketMessage = function(transaction) {
-  var message = {
-    janus: 'error',
-    error: {
-      code: this.code || 490,
-      reason: this.message
-    }
-  };
-  if (transaction) {
-    message.transaction = transaction;
-  }
-  return message;
-};
-
 function WarningError(message, code) {
   WarningError.super_.apply(this, arguments);
 }

--- a/lib/janus/error.js
+++ b/lib/janus/error.js
@@ -1,16 +1,11 @@
-var _ = require('underscore');
 var util = require('util');
 
 /**
  * @param {String} message
  * @param {Number} [code]
- * @param {String} [transaction]
  * @constructor
  */
-function JanusError(message, code, transaction) {
-
-  /** @type {String} */
-  this.transaction = transaction;
+function JanusError(message, code) {
 
   /** @type {Number} */
   this.code = code;
@@ -21,7 +16,11 @@ function JanusError(message, code, transaction) {
 }
 util.inherits(JanusError, Error);
 
-JanusError.prototype.getWebSocketMessage = function() {
+/**
+ * @param {String} [transaction]
+ * @returns {{janus: string, error: {code: (*|number), reason: (String|*)}}}
+ */
+JanusError.prototype.getWebSocketMessage = function(transaction) {
   var message = {
     janus: 'error',
     error: {
@@ -29,44 +28,44 @@ JanusError.prototype.getWebSocketMessage = function() {
       reason: this.message
     }
   };
-  if (this.transaction) {
-    message.transaction = this.transaction;
+  if (transaction) {
+    message.transaction = transaction;
   }
   return message;
 };
 
-function WarningError(message, code, transaction) {
+function WarningError(message, code) {
   WarningError.super_.apply(this, arguments);
 }
 util.inherits(WarningError, JanusError);
 
-function FatalError(message, code, transaction) {
+function FatalError(message, code) {
   FatalError.super_.apply(this, arguments);
 }
 util.inherits(FatalError, JanusError);
 
-function UnauthorizedError(transaction) {
-  UnauthorizedError.super_.call(this, 'Unauthorized request', 403, transaction);
+function UnauthorizedError() {
+  UnauthorizedError.super_.call(this, 'Unauthorized request', 403);
 }
 util.inherits(UnauthorizedError, WarningError);
 
-function IllegalPluginError(transaction) {
-  IllegalPluginError.super_.call(this, 'Illegal plugin to access', 405, transaction);
+function IllegalPluginError() {
+  IllegalPluginError.super_.call(this, 'Illegal plugin to access', 405);
 }
 util.inherits(IllegalPluginError, WarningError);
 
-function UnknownError(transaction) {
-  UnknownError.super_.call(this, 'Unknown error', 490, transaction);
+function UnknownError() {
+  UnknownError.super_.call(this, 'Unknown error', 490);
 }
 util.inherits(UnknownError, FatalError);
 
-function InvalidPlugin(transaction, pluginId) {
-  InvalidPlugin.super_.call(this, 'No such plugin `' + pluginId + '`', 458, transaction);
+function InvalidPlugin(pluginId) {
+  InvalidPlugin.super_.call(this, 'No such plugin `' + pluginId + '`', 458);
 }
 util.inherits(InvalidPlugin, JanusError);
 
-function InvalidSession(transaction, sessionId) {
-  InvalidSession.super_.call(this, 'No such session `' + sessionId + '`', 458, transaction);
+function InvalidSession(sessionId) {
+  InvalidSession.super_.call(this, 'No such session `' + sessionId + '`', 458);
 }
 util.inherits(InvalidSession, JanusError);
 

--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -56,7 +56,7 @@ PluginStreaming.prototype.subscribe = function(message) {
     })
     .catch(JanusError.Error, function(error) {
       serviceLocator.get('http-client').detach(plugin);
-      throw new JanusError.Error('Cannot subscribe: ' + plugin.stream + ' for ' + plugin + 'error: ' + error.message, 490, message['transaction']);
+      throw new JanusError.Error('Cannot subscribe: ' + plugin.stream + ' for ' + plugin + 'error: ' + error.message, 490);
     });
 };
 
@@ -78,7 +78,7 @@ PluginStreaming.prototype.publish = function(message) {
     })
     .catch(JanusError.Error, function(error) {
       serviceLocator.get('http-client').detach(plugin);
-      throw new JanusError.Error('Cannot publish: ' + plugin.stream + ' for ' + plugin + ' error: ' + error.message, 490, message['transaction']);
+      throw new JanusError.Error('Cannot publish: ' + plugin.stream + ' for ' + plugin + ' error: ' + error.message, 490);
     });
 };
 

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -61,8 +61,8 @@ JanusProxy.prototype.establishConnection = function(fromClientConnection, toJanu
   var connection = proxy.createConnection(fromClientConnection, toJanusConnection);
   proxy.addConnection(connection);
 
-  var handleError = function(error, request) {
-    proxy.handleError(error, fromClientConnection, request ? request['transaction'] : null);
+  var handleError = function(error, transaction) {
+    proxy.handleError(error, fromClientConnection, transaction);
   };
 
   fromClientConnection.on('message', function(request) {
@@ -71,7 +71,7 @@ JanusProxy.prototype.establishConnection = function(fromClientConnection, toJanu
         toJanusConnection.send(processedRequest);
       })
       .catch(function(error) {
-        handleError(error, request);
+        handleError(error, request ? request['transaction'] : null);
       });
   });
 
@@ -81,7 +81,7 @@ JanusProxy.prototype.establishConnection = function(fromClientConnection, toJanu
         fromClientConnection.send(processedRequest);
       })
       .catch(function(error) {
-        handleError(error, request);
+        handleError(error, request ? request['transaction'] : null);
       });
   });
 

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -61,20 +61,24 @@ JanusProxy.prototype.establishConnection = function(fromClientConnection, toJanu
   var connection = proxy.createConnection(fromClientConnection, toJanusConnection);
   proxy.addConnection(connection);
 
-  var handleError = function(error) {
-    proxy.handleError(error, fromClientConnection);
+  var handleError = function(error, request) {
+    proxy.handleError(error, fromClientConnection, request ? request['transaction'] : null);
   };
 
   fromClientConnection.on('message', function(request) {
     connection.processMessage(request).then(function(processedRequest) {
       toJanusConnection.send(processedRequest);
-    }, handleError);
+    }, function(error) {
+      handleError(error, request);
+    });
   });
 
   toJanusConnection.on('message', function(request) {
     connection.processMessage(request).then(function(processedRequest) {
       fromClientConnection.send(processedRequest);
-    }, handleError);
+    }, function(error) {
+      handleError(error, request);
+    });
   });
 
   fromClientConnection.on('close', function() {
@@ -102,14 +106,18 @@ JanusProxy.prototype.establishConnection = function(fromClientConnection, toJanu
 /**
  * @param {Error} error
  * @param {Connection} fromClientConnection
+ * @param {String} [transaction]
  */
-JanusProxy.prototype.handleError = function(error, fromClientConnection) {
+JanusProxy.prototype.handleError = function(error, fromClientConnection, transaction) {
   if (error instanceof JanusError.Fatal || !(error instanceof JanusError.Error)) {
     var logMessage = error.stack || error.message || error;
     serviceLocator.get('logger').error(logMessage);
     fromClientConnection.close();
   } else {
     serviceLocator.get('logger').info(error);
+    if (transaction) {
+      error.transaction = transaction;
+    }
     fromClientConnection.send(error.getWebSocketMessage());
   }
 };

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -71,7 +71,7 @@ JanusProxy.prototype.establishConnection = function(fromClientConnection, toJanu
         toJanusConnection.send(processedRequest);
       })
       .catch(function(error) {
-        handleError(error, request ? request['transaction'] : null);
+        handleError(error, request['transaction']);
       });
   });
 

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -115,10 +115,17 @@ JanusProxy.prototype.handleError = function(error, fromClientConnection, transac
     fromClientConnection.close();
   } else {
     serviceLocator.get('logger').info(error);
+    var errorMessage = {
+      janus: 'error',
+      error: {
+        code: error.code || 490,
+        reason: error.message
+      }
+    };
     if (transaction) {
-      error.transaction = transaction;
+      errorMessage.transaction = transaction;
     }
-    fromClientConnection.send(error.getWebSocketMessage());
+    fromClientConnection.send(errorMessage);
   }
 };
 

--- a/lib/janus/session.js
+++ b/lib/janus/session.js
@@ -41,7 +41,7 @@ Session.prototype.processMessage = function(message) {
     if (plugin) {
       return plugin.processMessage(message);
     } else {
-      return Promise.reject(new JanusError.InvalidPlugin(message['transaction'], pluginId));
+      return Promise.reject(new JanusError.InvalidPlugin(pluginId));
     }
   }
 
@@ -55,7 +55,7 @@ Session.prototype.processMessage = function(message) {
 Session.prototype.onAttach = function(message) {
   var self = this;
   if (!this.pluginRegistry.isAllowedPlugin(message['plugin'])) {
-    return Promise.reject(new JanusError.IllegalPlugin(message['transaction']));
+    return Promise.reject(new JanusError.IllegalPlugin());
   }
 
   this.connection.transactions.add(message['transaction'], function(response) {


### PR DESCRIPTION
Transaction should be only added in proxy error handler (on top of the stack). We currently are not able to pass valid transaction from methods we still want to throw `Janus` errors.