### PR TITLE
Make removing of connections, sessions, plugins promise-based

### DIFF
--- a/lib/janus/connection.js
+++ b/lib/janus/connection.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var Promise = require('bluebird');
 var Transactions = require('./transactions');
 var Session = require('./session');
@@ -91,8 +90,9 @@ JanusConnection.prototype.onCreate = function(message) {
  */
 JanusConnection.prototype.onDestroy = function(message) {
   this.transactions.add(message['transaction'], function(response) {
-    this._removeSession();
-    return Promise.resolve(response);
+    return this._removeSession().then(function() {
+      return response
+    });
   }.bind(this));
   return Promise.resolve(message);
 };
@@ -107,15 +107,18 @@ JanusConnection.prototype.onTimeout = function(message) {
 };
 
 JanusConnection.prototype.onRemove = function() {
-  this._removeSession();
-  serviceLocator.get('logger').info('Removed ' + this);
+  return this._removeSession().finally(function() {
+    serviceLocator.get('logger').info('Removed ' + this);
+  }.bind(this));
 };
 
 JanusConnection.prototype._removeSession = function() {
   if (null !== this.session) {
-    this.session.onRemove();
-    this.session = null;
+    return this.session.onRemove().finally(function() {
+      this.session = null;
+    }.bind(this));
   }
+  return Promise.resolve();
 };
 
 /**

--- a/lib/janus/connection.js
+++ b/lib/janus/connection.js
@@ -114,7 +114,7 @@ JanusConnection.prototype.onRemove = function() {
 
 JanusConnection.prototype._removeSession = function() {
   if (null !== this.session) {
-    return this.session.onRemove().finally(function() {
+    return this.session.onRemove().then(function() {
       this.session = null;
     }.bind(this));
   }

--- a/lib/janus/connection.js
+++ b/lib/janus/connection.js
@@ -107,7 +107,7 @@ JanusConnection.prototype.onTimeout = function(message) {
 };
 
 JanusConnection.prototype.onRemove = function() {
-  return this._removeSession().finally(function() {
+  return this._removeSession().then(function() {
     serviceLocator.get('logger').info('Removed ' + this);
   }.bind(this));
 };

--- a/lib/janus/plugin/abstract.js
+++ b/lib/janus/plugin/abstract.js
@@ -1,6 +1,5 @@
 var Promise = require('bluebird');
 var serviceLocator = require('../../service-locator');
-var Channel = require('../../channel');
 
 /**
  * @param {String} id
@@ -45,6 +44,7 @@ PluginAbstract.prototype._isSuccessResponse = function(response) {
 
 PluginAbstract.prototype.onRemove = function() {
   serviceLocator.get('logger').info('Removed ' + this);
+  return Promise.resolve();
 };
 
 PluginAbstract.prototype.toString = function() {

--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -83,7 +83,7 @@ PluginStreaming.prototype.getStream = function() {
 
 PluginStreaming.prototype.removeStream = function() {
   if (this.stream) {
-    return serviceLocator.get('streams').remove(this.getStream()).finally(function() {
+    return serviceLocator.get('streams').remove(this.getStream()).then(function() {
       this.stream = null;
     }.bind(this));
   }

--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -83,14 +83,17 @@ PluginStreaming.prototype.getStream = function() {
 
 PluginStreaming.prototype.removeStream = function() {
   if (this.stream) {
-    serviceLocator.get('streams').remove(this.getStream());
-    this.stream = null;
+    return serviceLocator.get('streams').remove(this.getStream()).finally(function() {
+      this.stream = null;
+    }.bind(this));
   }
+  return Promise.resolve();
 };
 
 PluginStreaming.prototype.onRemove = function() {
-  this.removeStream();
-  PluginStreaming.super_.prototype.onRemove.call(this);
+  return this.removeStream().finally(function() {
+    PluginStreaming.super_.prototype.onRemove.call(this);
+  }.bind(this));
 };
 
 module.exports = PluginStreaming;

--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -91,7 +91,7 @@ PluginStreaming.prototype.removeStream = function() {
 };
 
 PluginStreaming.prototype.onRemove = function() {
-  return this.removeStream().finally(function() {
+  return this.removeStream().then(function() {
     PluginStreaming.super_.prototype.onRemove.call(this);
   }.bind(this));
 };

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -162,7 +162,7 @@ JanusProxy.prototype.addConnection = function(connection) {
  */
 JanusProxy.prototype.removeConnection = function(connection) {
   if (this.connections[connection.id]) {
-    return connection.onRemove().finally(function() {
+    return connection.onRemove().then(function() {
       delete this.connections[connection.id];
     }.bind(this));
   }

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -162,22 +162,21 @@ JanusProxy.prototype.addConnection = function(connection) {
  */
 JanusProxy.prototype.removeConnection = function(connection) {
   if (this.connections[connection.id]) {
-    connection.onRemove();
-    delete this.connections[connection.id];
+    return connection.onRemove().finally(function() {
+      delete this.connections[connection.id];
+    }.bind(this));
   }
+  return Promise.resolve();
 };
 
 /**
  * @returns {Promise}
  */
 JanusProxy.prototype.stop = function() {
-  var proxy = this;
-  _.each(proxy.connections,
-    function(connection) {
-      proxy.removeConnection(connection);
-    }
-  );
-  return Promise.resolve();
+  return Promise.all(
+    _.map(this.connections, function(connection) {
+      return this.removeConnection(connection).reflect();
+    }.bind(this)));
 };
 
 module.exports = JanusProxy;

--- a/lib/janus/session.js
+++ b/lib/janus/session.js
@@ -86,7 +86,7 @@ Session.prototype.onDetached = function(message) {
  */
 Session.prototype._removePlugin = function(id) {
   if (this.plugins[id]) {
-    return this.plugins[id].onRemove().finally(function() {
+    return this.plugins[id].onRemove().then(function() {
       delete this.plugins[id];
     }.bind(this));
   }

--- a/lib/janus/session.js
+++ b/lib/janus/session.js
@@ -86,16 +86,20 @@ Session.prototype.onDetached = function(message) {
  */
 Session.prototype._removePlugin = function(id) {
   if (this.plugins[id]) {
-    this.plugins[id].onRemove();
-    delete this.plugins[id];
+    return this.plugins[id].onRemove().finally(function() {
+      delete this.plugins[id];
+    }.bind(this));
   }
+  return Promise.resolve();
 };
 
 Session.prototype.onRemove = function() {
-  _.each(this.plugins, function(plugin, id) {
-    this._removePlugin(id);
-  }.bind(this));
-  serviceLocator.get('logger').info('Removed ' + this);
+  var self = this;
+  return Promise.all(_.map(this.plugins, function(plugin, id) {
+    return self._removePlugin(id).reflect();
+  })).finally(function() {
+    serviceLocator.get('logger').info('Removed ' + self);
+  });
 };
 
 Session.prototype.toString = function() {

--- a/lib/janus/session.js
+++ b/lib/janus/session.js
@@ -97,7 +97,7 @@ Session.prototype.onRemove = function() {
   var self = this;
   return Promise.all(_.map(this.plugins, function(plugin, id) {
     return self._removePlugin(id).reflect();
-  })).finally(function() {
+  })).then(function() {
     serviceLocator.get('logger').info('Removed ' + self);
   });
 };

--- a/test/spec/janus/connection.js
+++ b/test/spec/janus/connection.js
@@ -94,6 +94,7 @@ describe('JanusConnection', function() {
       };
       sinon.spy(connection.transactions, 'add');
       connection.session = sinon.createStubInstance(Session);
+      connection.session.onRemove.returns(Promise.resolve());
       connection.processMessage(message);
     });
 
@@ -102,10 +103,12 @@ describe('JanusConnection', function() {
     });
 
     context('on successful transaction response', function() {
-      beforeEach(function() {
+      beforeEach(function(done) {
         var transactionCallback = connection.transactions.add.firstCall.args[1];
         transactionCallback({
           janus: 'success'
+        }).then(function() {
+          done()
         });
       });
 
@@ -116,13 +119,16 @@ describe('JanusConnection', function() {
   });
 
   context('when processes "timeout" message"', function() {
-    beforeEach(function() {
+    beforeEach(function(done) {
       var message = {
         janus: 'timeout',
         sessionId: 'session-id'
       };
       connection.session = sinon.createStubInstance(Session);
-      connection.processMessage(message);
+      connection.session.onRemove.returns(Promise.resolve());
+      connection.processMessage(message).then(function() {
+        done()
+      });
     });
 
     it('should remove session', function() {
@@ -158,6 +164,7 @@ describe('JanusConnection', function() {
     context('when session exists', function() {
       beforeEach(function() {
         connection.session = sinon.createStubInstance(Session);
+        connection.session.onRemove.returns(Promise.resolve());
       });
 
       it('should trigger session onRemove', function() {
@@ -167,8 +174,9 @@ describe('JanusConnection', function() {
       });
 
       it('should clear session', function() {
-        connection.onRemove();
-        expect(connection.session).to.be.equal(null);
+        connection.onRemove().then(function() {
+          expect(connection.session).to.be.equal(null);
+        });
       });
     });
   });

--- a/test/spec/janus/plugin/audio.js
+++ b/test/spec/janus/plugin/audio.js
@@ -30,6 +30,7 @@ describe('Audio plugin', function() {
     session = new Session(connection, 'session-id', 'session-data');
     plugin = new PluginAudio('id', 'type', session);
     streams = sinon.createStubInstance(Streams);
+    streams.remove.returns(Promise.resolve());
     serviceLocator.register('streams', streams);
 
     connection.session = session;
@@ -161,10 +162,7 @@ describe('Audio plugin', function() {
   });
 
   it('change room', function(done) {
-    streams.addSubscribe.restore();
-    sinon.stub(streams, 'addSubscribe', function() {
-      return Promise.resolve();
-    });
+    streams.addSubscribe.returns(Promise.resolve());
 
     var changeroomRequest = {
       janus: 'message',
@@ -191,10 +189,7 @@ describe('Audio plugin', function() {
   });
 
   it('change room fail', function(done) {
-    streams.addSubscribe.restore();
-    sinon.stub(streams, 'addSubscribe', function() {
-      return Promise.resolve();
-    });
+    streams.addSubscribe.returns(Promise.resolve());
     streams.has.returns(true);
 
     var changeroomRequest = {

--- a/test/spec/janus/plugin/streaming.js
+++ b/test/spec/janus/plugin/streaming.js
@@ -39,11 +39,7 @@ describe('PluginStreaming', function() {
           janus: 'webrtcup'
         });
       };
-
-      streams.addSubscribe.restore();
-      sinon.stub(streams, 'addSubscribe', function() {
-        return Promise.resolve();
-      });
+      streams.addSubscribe.returns(Promise.resolve());
     });
 
     it('should subscribe', function(done) {
@@ -64,10 +60,7 @@ describe('PluginStreaming', function() {
 
     context('on unsuccessful subscribe', function() {
       beforeEach(function() {
-        streams.addSubscribe.restore();
-        sinon.stub(streams, 'addSubscribe', function() {
-        return Promise.reject(new JanusError.Error('Cannot subscribe'));
-        });
+        streams.addSubscribe.returns(Promise.reject(new JanusError.Error('Cannot subscribe')));
       });
 
       it('should detach and should reject', function(done) {
@@ -101,7 +94,9 @@ describe('PluginStreaming', function() {
 
   context('when removed', function() {
     it('should remove stream', function() {
-      sinon.stub(plugin, 'removeStream');
+      sinon.stub(plugin, 'removeStream', function() {
+        return Promise.resolve();
+      });
       plugin.onRemove();
       expect(plugin.removeStream.calledOnce).to.be.equal(true);
     });
@@ -116,8 +111,11 @@ describe('PluginStreaming', function() {
       streams.has.returns(true);
     });
     context('when removes stream', function() {
-      beforeEach(function() {
-        plugin.removeStream();
+      beforeEach(function(done) {
+        streams.remove.returns(Promise.resolve());
+        plugin.removeStream().then(function() {
+          done()
+        });
       });
 
       it('should remove stream reference', function() {

--- a/test/spec/janus/session.js
+++ b/test/spec/janus/session.js
@@ -103,16 +103,19 @@ describe('Session', function() {
   context('when removes plugin', function() {
     beforeEach(function() {
       session.plugins['plugin-id'] = sinon.createStubInstance(PluginAbstract);
+      session.plugins['plugin-id'].onRemove.returns(Promise.resolve());
       session.plugins['other-plugin-id'] = sinon.createStubInstance(PluginAbstract);
+      session.plugins['other-plugin-id'].onRemove.returns(Promise.resolve());
     });
 
 
     it('should remove it from plugins collection', function() {
       expect(_.size(session.plugins), 2);
       expect(session.plugins).to.have.property('plugin-id');
-      session._removePlugin('plugin-id');
-      expect(_.size(session.plugins), 1);
-      expect(session.plugins).to.not.have.property('plugin-id');
+      session._removePlugin('plugin-id').then(function() {
+        expect(_.size(session.plugins), 1);
+        expect(session.plugins).to.not.have.property('plugin-id');
+      });
     });
 
     it('should trigger onRemove', function() {
@@ -139,10 +142,7 @@ describe('Session', function() {
     it('should proxy message to plugin', function() {
       var plugin = sinon.createStubInstance(PluginAbstract);
       session.plugins['plugin-id'] = plugin;
-      plugin.processMessage.restore();
-      sinon.stub(plugin, 'processMessage', function() {
-        return Promise.resolve();
-      });
+      plugin.processMessage.returns(Promise.resolve());
       session.processMessage(message);
       assert(plugin.processMessage.withArgs(message).calledOnce);
     });


### PR DESCRIPTION
As discussed keep `onRemove` and `_remove*` methods. Promisify them.