### PR TITLE
Add timeout for job processing

### DIFF
--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -31,6 +31,9 @@ function AbstractJob(id, jobData, configuration) {
 
   /** @type {String|null} */
   this._workingDirectory = null;
+
+  /** @type {Number} */
+  this._maxRunningTime = 24 * 60 * 60;// in seconds
 }
 
 /**
@@ -66,8 +69,19 @@ AbstractJob.prototype.getWorkingDirectory = function() {
  */
 AbstractJob.prototype.run = function() {
   this._promise = this._run();
+  this._setTimeoutCancel();
   return this._promise;
 };
+
+AbstractJob.prototype._setTimeoutCancel = function() {
+  var outdatedTimeout = setTimeout(function() {
+    this.cancel();
+  }.bind(this), this._maxRunningTime);
+  this._promise.finally(function() {
+    clearTimeout(outdatedTimeout);
+  });
+};
+
 /**
  * @returns {Promise}
  */

--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -75,6 +75,7 @@ AbstractJob.prototype.run = function() {
 
 AbstractJob.prototype._setTimeoutCancel = function() {
   var outdatedTimeout = setTimeout(function() {
+    serviceLocator.get('logger').warn('Killing long-running job' + this);
     this.cancel();
   }.bind(this), this._maxRunningTime);
   this._promise.finally(function() {

--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -68,19 +68,8 @@ AbstractJob.prototype.getWorkingDirectory = function() {
  * @returns {Promise}
  */
 AbstractJob.prototype.run = function() {
-  this._promise = this._run();
-  this._setTimeoutCancel();
+  this._promise = this._run().timeout(this._maxRunningTime);
   return this._promise;
-};
-
-AbstractJob.prototype._setTimeoutCancel = function() {
-  var outdatedTimeout = setTimeout(function() {
-    serviceLocator.get('logger').warn('Killing long-running job' + this);
-    this.cancel();
-  }.bind(this), this._maxRunningTime);
-  this._promise.finally(function() {
-    clearTimeout(outdatedTimeout);
-  });
 };
 
 /**

--- a/test/spec/job/model/abstract.js
+++ b/test/spec/job/model/abstract.js
@@ -105,6 +105,9 @@ describe('AbstractJob', function() {
 
     it('cancel overran jobs', function(done) {
       sinon.spy(job, 'cancel');
+      sinon.stub(job, 'getName', function() {
+        return ''
+      });
       job._maxRunningTime = jobRunTime / 2;
       job.run().finally(function() {
         assert.isTrue(job.cancel.calledOnce);

--- a/test/spec/job/model/abstract.js
+++ b/test/spec/job/model/abstract.js
@@ -89,6 +89,7 @@ describe('AbstractJob', function() {
 
   context('timeout cancel', function() {
     var job, jobRunTime = 2000;
+    this.timeout(jobRunTime + 100);
 
     beforeEach(function() {
       job = new AbstractJob();
@@ -97,20 +98,14 @@ describe('AbstractJob', function() {
       };
     });
 
-    it('charges timeout cancellation', function() {
-      sinon.spy(job, '_setTimeoutCancel');
-      job.run();
-      assert.isTrue(job._setTimeoutCancel.calledOnce);
+    it('run job ok within the timeout', function(done) {
+      job._maxRunningTime = jobRunTime * 2;
+      job.run().then(done);
     });
 
-    it('cancel overran jobs', function(done) {
-      sinon.spy(job, 'cancel');
-      sinon.stub(job, 'getName', function() {
-        return ''
-      });
+    it('reject overran jobs', function(done) {
       job._maxRunningTime = jobRunTime / 2;
-      job.run().finally(function() {
-        assert.isTrue(job.cancel.calledOnce);
+      job.run().catch(Promise.TimeoutError, function() {
         done();
       });
     });

--- a/test/spec/job/model/abstract.js
+++ b/test/spec/job/model/abstract.js
@@ -15,7 +15,8 @@ describe('AbstractJob', function() {
     beforeEach(function() {
       job = new AbstractJob();
       job._run = function() {
-        return new Promise(function(resolve, reject) {});
+        return new Promise(function(resolve, reject) {
+        });
       };
       job.run();
     });
@@ -83,6 +84,32 @@ describe('AbstractJob', function() {
         assert.equal(output.trim(), workingDirectory);
         done();
       })
+    });
+  });
+
+  context('timeout cancel', function() {
+    var job, jobRunTime = 2000;
+
+    beforeEach(function() {
+      job = new AbstractJob();
+      job._run = function() {
+        return Promise.delay(jobRunTime);
+      };
+    });
+
+    it('charges timeout cancellation', function() {
+      sinon.spy(job, '_setTimeoutCancel');
+      job.run();
+      assert.isTrue(job._setTimeoutCancel.calledOnce);
+    });
+
+    it('cancel overran jobs', function(done) {
+      sinon.spy(job, 'cancel');
+      job._maxRunningTime = jobRunTime / 2;
+      job.run().finally(function() {
+        assert.isTrue(job.cancel.calledOnce);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
Currently I'm investigating a job conversion that's running for 9 days now (!). The file is 103GB, but still this is too long.

@tomaszdurka @vogdb should we add a timeout?

cc @kris-lab 