### PR TITLE
Remove failed jobs working directories

### DIFF
--- a/lib/job/processor.js
+++ b/lib/job/processor.js
@@ -74,8 +74,8 @@ JobProcessor.prototype._process = function(job) {
   var workingDirectory = this._createJobWorkingDirectory(job);
   job.setWorkingDirectory(workingDirectory);
   return job.run()
-    .then(function(result) {
-      return rimraf(workingDirectory).return(result);
+    .finally(function() {
+      return rimraf(workingDirectory);
     });
 };
 


### PR DESCRIPTION
Before we decided to keep failed jobs WD to investigate, not relevant for now.