### PR TITLE
Allow to run cm-janus with specific modules only

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Run services using:
 ```
 bin/cm-janus
 ```
+
+### Config
 cm-janus is based on single configuration file written in yaml format. Default config is present under [`bin/config.yaml`](bin/config.yaml).
 You can provide different config file using `-c` option (e.g. `bin/cm-janus -c /path/to/my/config/yaml`). New config will completely overwrite old one. Old one won't be used for defaults.
-
-By default cm-janus runs for all roles (server, jobs). This can be limited by passing `-r` argument (e.g. `bin/cm-janus -r server,jobs`).
 
 Config format:
 
@@ -59,6 +59,10 @@ jobManager:
     'janus.plugin.cm.rtpbroadcast:thumbnailing-finished': # video thumbnail job handler
       createThumbnailCommand: 'mjr2png <%= videoMjrFile %> 1920 560 <%= pngFile %>' # a command to use for converting mjr into png
 ```
+
+### Roles
+
+By default cm-janus runs for all roles (server, jobs). This can be limited by passing `-r` argument (e.g. `bin/cm-janus -r server,jobs`).
 
 ## Testing
 cm-janus uses [node-inotify](https://github.com/c4milo/node-inotify) that works only in GNU/Linux. To run tests on any other platform you need to setup a virtual Linux environment. For Vagrant users there is a prepared vagrant file.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ bin/cm-janus
 ```
 cm-janus is based on single configuration file written in yaml format. Default config is present under [`bin/config.yaml`](bin/config.yaml).
 You can provide different config file using `-c` option (e.g. `bin/cm-janus -c /path/to/my/config/yaml`). New config will completely overwrite old one. Old one won't be used for defaults.
+By default cm-janus runs for all roles (server, jobs). This can be limited by passing `-r` argument (e.g. `bin/cm-janus -r server,jobs`).
 
 Config format:
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ bin/cm-janus
 ```
 cm-janus is based on single configuration file written in yaml format. Default config is present under [`bin/config.yaml`](bin/config.yaml).
 You can provide different config file using `-c` option (e.g. `bin/cm-janus -c /path/to/my/config/yaml`). New config will completely overwrite old one. Old one won't be used for defaults.
+
 By default cm-janus runs for all roles (server, jobs). This can be limited by passing `-r` argument (e.g. `bin/cm-janus -r server,jobs`).
 
 Config format:

--- a/bin/cm-janus
+++ b/bin/cm-janus
@@ -1,13 +1,22 @@
 #!/usr/bin/env node
 var minimist = require('minimist');
+var _ = require('underscore');
 var Config = require('../lib/config');
 var Application = require('../lib/index.js');
 
 var argv = minimist(process.argv.slice(2));
 var configPath = argv.c || __dirname + '/config.yaml';
-var config = Config.createFromFile(configPath).asHash();
+var availableRoles = ['server', 'jobs'];
+var roles = availableRoles;
+if (argv.r) {
+  roles = argv.r.split(',');
+  var invalidRoles = _.difference(roles, availableRoles);
+  if (invalidRoles.length) {
+    throw new Error('Invalid roles: ' + invalidRoles);
+  }
+}
 
-var application = new Application(config);
+var config = Config.createFromFile(configPath).asHash();
+var application = new Application(config, roles);
 application.registerServices();
 application.start();
-

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -82,15 +82,37 @@ HttpServer.prototype.installRoutes = function(router) {
 
 };
 
+/**
+ * @returns {Promise}
+ */
 HttpServer.prototype.start = function() {
   var self = this;
   return new Promise(function(resolve) {
-      self.server.listen(self.port, function() {
-        serviceLocator.get('logger').debug('HTTP server on port ' + self.port + ' started');
-        resolve();
+      self.server.listen(self.port, function(err) {
+        if (err) {
+          reject(err);
+        } else {
+          serviceLocator.get('logger').debug('HTTP server on port ' + self.port + ' started');
+          resolve();
+        }
       });
     }
   );
+};
+
+/**
+ * @returns {Promise}
+ */
+HttpServer.prototype.stop = function() {
+  return new Promise(function(resolve, reject) {
+    this.server.close(function(err) {
+      if (err) {
+        reject();
+      } else {
+        resolve();
+      }
+    });
+  }.bind(this))
 };
 
 module.exports = HttpServer;

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -107,7 +107,7 @@ HttpServer.prototype.stop = function() {
   return new Promise(function(resolve, reject) {
     this.server.close(function(err) {
       if (err) {
-        reject();
+        reject(err);
       } else {
         resolve();
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,8 +12,14 @@ var JanusProxy = require('./janus/proxy');
 var JobManager = require('./job/manager');
 var Promise = require('bluebird');
 
-function Application(config) {
+/**
+ * @param {Config} config
+ * @param {Array} roles
+ * @constructor
+ */
+function Application(config, roles) {
   this.config = config;
+  this.roles = roles;
 }
 
 Application.prototype.registerServices = function() {
@@ -65,17 +71,26 @@ Application.prototype.registerServices = function() {
   }.bind(this));
 };
 
-Application.prototype.start = function() {
-  var proxy = new JanusProxy(this.config['webSocketServer']['port'], this.config['janus']['webSocketAddress']);
-  var httpServer = new HttpServer(this.config['httpServer']['port'], this.config['httpServer']['apiKey']);
-  var jobManager = new JobManager(this.config['jobManager']['jobsPath'], this.config['jobManager']['tempFilesPath']);
-  jobManager.handlerRegistry.registerFromConfiguration(this.config['jobManager']['handlersConfiguration']);
 
-  new Promise.all([
-    proxy.start(),
-    httpServer.start(),
-    jobManager.start()
-  ]).catch(function(error) {
+Application.prototype.start = function() {
+  var services = [];
+
+  if (_.contains(this.roles, 'server')) {
+    var proxy = new JanusProxy(this.config['webSocketServer']['port'], this.config['janus']['webSocketAddress']);
+    var httpServer = new HttpServer(this.config['httpServer']['port'], this.config['httpServer']['apiKey']);
+    services.push(proxy);
+    services.push(httpServer);
+  }
+
+  if (_.contains(this.roles, 'jobs')) {
+    var jobManager = new JobManager(this.config['jobManager']['jobsPath'], this.config['jobManager']['tempFilesPath']);
+    jobManager.handlerRegistry.registerFromConfiguration(this.config['jobManager']['handlersConfiguration']);
+    services.push(jobManager);
+  }
+
+  Promise.map(services, function(service) {
+    return service.start();
+  }).catch(function(error) {
     serviceLocator.get('logger').error('Process failed. Exiting. ' + error.stack || error.message);
     process.emit('close');
   });
@@ -99,7 +114,9 @@ Application.prototype.start = function() {
 
   process.on('close', function() {
     serviceLocator.get('logger').info('Closing application');
-    Promise.all([jobManager.stop(), proxy.stop()]).finally(function() {
+    Promise.map(services, function(service) {
+      return service.stop();
+    }).finally(function() {
       process.nextTick(process.exit(1));
     });
   });


### PR DESCRIPTION
Allow to pass command-line option to run only specific modules, example usages:

```
 # runs all modules
cm-janus -c <config-file>

 # runs only server/job-manager
cm-janus -c <config-file> --server
cm-janus -c <config-file> --job-manager

# or rather
cm-janus -c <config-file> --roles=server,job-manager
```