### PR TITLE
Fails to start if cm can't be reached

### DIFF
--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -29,26 +29,26 @@ JanusProxy.prototype.start = function() {
       serviceLocator.get('logger').warn('Can\'t remove streams on startup', error);
     })
     .then(function() {
-    var webSocketServer = proxy.getWebSocketServer();
+      var webSocketServer = proxy.getWebSocketServer();
 
-    webSocketServer.on('connection', function(incomingConnection) {
-      try {
-        var outgoingConnection = proxy.openWebSocket();
-        var fromClientConnection = new Connection('browser', incomingConnection);
-        var toJanusConnection = new Connection('janus', outgoingConnection);
-        proxy.establishConnection(fromClientConnection, toJanusConnection);
+      webSocketServer.on('connection', function(incomingConnection) {
+        try {
+          var outgoingConnection = proxy.openWebSocket();
+          var fromClientConnection = new Connection('browser', incomingConnection);
+          var toJanusConnection = new Connection('janus', outgoingConnection);
+          proxy.establishConnection(fromClientConnection, toJanusConnection);
 
-      } catch (error) {
-        serviceLocator.get('logger').error('Unexpected JanusProxy runtime error: ' + error);
-        if (fromClientConnection) {
-          fromClientConnection.close();
+        } catch (error) {
+          serviceLocator.get('logger').error('Unexpected JanusProxy runtime error: ' + error);
+          if (fromClientConnection) {
+            fromClientConnection.close();
+          }
+          if (toJanusConnection) {
+            toJanusConnection.close();
+          }
         }
-        if (toJanusConnection) {
-          toJanusConnection.close();
-        }
-      }
+      });
     });
-  });
 };
 
 /**

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -24,7 +24,11 @@ function JanusProxy(listenPort, janusAddress) {
  */
 JanusProxy.prototype.start = function() {
   var proxy = this;
-  return serviceLocator.get('streams').removeAll().then(function() {
+  return serviceLocator.get('streams').removeAll()
+    .catch(function(error) {
+      serviceLocator.get('logger').warn('Can\'t remove streams on startup', error);
+    })
+    .then(function() {
     var webSocketServer = proxy.getWebSocketServer();
 
     webSocketServer.on('connection', function(incomingConnection) {


### PR DESCRIPTION
When booting cm virtual machine:
cc @kris-lab @njam 

```
app debug WebSocket server on port 8210 started
app debug HTTP server on port 8100 started
app info Closing application
app debug WebSocket server on port 8210 started
app debug HTTP server on port 8100 started
app info Closing application
2016-03-07 11:22:45.294 INFO - cm-api request https://example.dev.cargomedia.ch/rpc/null { method: 'CM_Janus_RpcEndpoints.removeAllStreams',
  params: [ 'mad-panda' ] }
2016-03-07 11:22:45.332 DEBUG - HTTP server on port 8100 started
2016-03-07 11:22:49.534 ERROR - Process failed. Exiting. Error: cm-api error: 500 - <h1>CM_Db_Exception</h1><h2>Database connection failed: SQLSTATE[42000] [1049] Unknown database 'sk'</h2><pre>/home/vagrant/sk/vendor/cargomedia/cm/library/CM/Db/Client.php on line 75</pre><pre>     0. {main} /home/vagrant/sk/public/index.php:0
     1. CM_Http_Handler->processRequest(CM_Http_Request_Post) /home/vagrant/sk/public/index.php:8
     2. CM_Http_Response_Abstract->factory(CM_Http_Request_Post, CM_Service_Manager) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Handler.php:21
     3. CM_Http_Response_Abstract->__construct(CM_Http_Request_Post, CM_Service_Manager) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php:311
     4. CM_Http_Request_Abstract->popPathLanguage() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Response/Abstract.php:38
     5. CM_Paging_Language_Abstract->findByAbbreviation('null') /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Http/Request/Abstract.php:201
     6. CM_Paging_Abstract->getItemsRaw() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Paging/Language/Abstract.php:14
     7. CM_Paging_Abstract->_getItemsRaw() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Paging/Abstract.php:88
     8. CM_PagingSource_Sql->getItems(NULL, NULL) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Paging/Abstract.php:362
     9. CM_Db_Db->exec('SELECT id, abbreviation FROM `...', [], NULL, CM_Db_Client) /home/vagrant/sk/vendor/cargomedia/cm/library/CM/PagingSource/Sql.php:101
    10. CM_Db_Client->createStatement('SELECT id, abbreviation FROM `...') /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Db/Db.php:65
    11. CM_Db_Client->connect() /home/vagrant/sk/vendor/cargomedia/cm/library/CM/Db/Client.php:172
</pre>

    at /usr/lib/node_modules/cm-janus/lib/cm-api-client.js:42:13
    at tryCatcher (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromises (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:697:14)
    at Async._drainQueue (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:367:17)
```
