### PR TITLE
Remove stream even after failed detach

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -63,8 +63,16 @@ HttpServer.prototype.installRoutes = function(router) {
         })
         .catch(function(error) {
           serviceLocator.get('logger').warn('Stream stop failed', error);
-          res.send({error: 'Stream stop failed'});
-          return next();
+          serviceLocator.get('logger').warn('Removing stream by force');
+          stream.plugin.onRemove()
+            .then(function() {
+              res.send({error: 'Stream stop failed. Stream was removed by force.'});
+              next();
+            })
+            .catch(function() {
+              res.send({error: 'Stream stop failed. Stream was not removed.'});
+              next();
+            });
         });
     } else {
       res.send({error: 'Unknown stream: ' + params['streamId']});


### PR DESCRIPTION
Currently we remove stream by detaching plugin with http call.
We should catch http-call error and remove stream from local storage anyway.

Example error:
```
2016-03-02 05:59:53.164 DEBUG - request /stopStream
2016-03-02 05:59:53.164 INFO - http-client request http://localhost:8300/janus/3502223475/1258294074 { janus: 'detach', transaction: 'vzk5cgx6sv' }
2016-03-02 05:59:53.166 INFO - http-client response { janus: 'error',
  session_id: 3502223475,
  transaction: 'vzk5cgx6sv',
  error: { code: 458, reason: 'No such session 3502223475' } }
2016-03-02 05:59:53.166 WARN - Stream stop failed [Error: http-client error: No such session 3502223475]
```