### PR TITLE
Cannot write to buffer - blocks process from running

### DIFF
--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -113,7 +113,7 @@ AbstractJob.prototype._runJobScript = function(commandText) {
   serviceLocator.get('logger').debug('Starting job process: `' + commandText + '`');
   var options = {
     cwd: this.getWorkingDirectory(),
-    capture: ['stdout']
+    capture: ['stdout', 'stderr']
   };
   var self = this;
   return this._spawn(command, commandArgs, options)


### PR DESCRIPTION
As investigated: looks like lame is exhausting node.js' STDERR buffer?

```
$ strace -p 12542
Process 12542 attached - interrupt to quit
write(2, "\33[A\33[A\33[A", 9
```