### PR TITLE
Add error information to  "Failed job process" exceptions

### DIFF
--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var spawn = require('child-process-promise').spawn;
+var NestedError = require('nested-error-stacks');
 var Promise = require('bluebird');
 var tmpName = Promise.promisify(require('tmp').tmpName);
 var rimraf = require('rimraf');
@@ -123,8 +124,8 @@ AbstractJob.prototype._runJobScript = function(commandText) {
     .then(function(result) {
       return result.stdout.toString();
     })
-    .catch(function() {
-      throw new Error('Failed job process: `' + commandText + '`');
+    .catch(function(error) {
+      throw new NestedError('Failed job process: `' + commandText + '`', error);
     })
     .finally(function() {
       self._process = null;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "log4js": "^0.6.29",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
+    "nested-error-stacks": "^1.0.2",
     "node-uuid": "^1.4.3",
     "request-promise": "^1.0.2",
     "rimraf": "^2.4.4",


### PR DESCRIPTION
Currently we get something like:

```
Error: Failed job process: `<command>`
    at /usr/lib/node_modules/cm-janus/lib/job/model/abstract.js:127:13
    at _rejected (/usr/lib/node_modules/cm-janus/node_modules/child-process-promise/node_modules/q/q.js:844:24)
    at /usr/lib/node_modules/cm-janus/node_modules/child-process-promise/node_modules/q/q.js:870:30
    at Promise.when (/usr/lib/node_modules/cm-janus/node_modules/child-process-promise/node_modules/q/q.js:1122:31)
    at Promise.promise.promiseDispatch (/usr/lib/node_modules/cm-janus/node_modules/child-process-promise/node_modules/q/q.js:788:41)
    at /usr/lib/node_modules/cm-janus/node_modules/child-process-promise/node_modules/q/q.js:604:44
    at runSingle (/usr/lib/node_modules/cm-janus/node_modules/child-process-promise/node_modules/q/q.js:137:13)
    at flush (/usr/lib/node_modules/cm-janus/node_modules/child-process-promise/node_modules/q/q.js:125:13)
    at process._tickCallback (node.js:355:11)
```