### PR TITLE
Use NestedError instead of concatenating error.stack with wrapper message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var log4js = require('log4js');
+var NestedError = require('nested-error-stacks');
 var serviceLocator = require('./service-locator');
 var CMApiClient = require('./cm-api-client');
 var JanusHttpClient = require('./janus/http-client');
@@ -91,16 +92,16 @@ Application.prototype.start = function() {
   Promise.map(services, function(service) {
     return service.start();
   }).catch(function(error) {
-    serviceLocator.get('logger').error('Process failed. Exiting. ' + error.stack || error.message);
+    serviceLocator.get('logger').error(new NestedError('Process failed. Exiting.', error));
     process.emit('close');
   });
 
   process.on('unhandledRejection', function(reason) {
-    serviceLocator.get('logger').error('Unexpected rejection error. ' + reason.stack || reason.message);
+    serviceLocator.get('logger').error(new NestedError('Unexpected rejection error.', reason));
   });
 
   process.on('uncaughtException', function(err) {
-    serviceLocator.get('logger').error('Unexpected runtime error. Shutdown the process ' + err.stack || err.message);
+    serviceLocator.get('logger').error(new NestedError('Unexpected runtime error. Shutdown the process ', err));
     process.emit('close');
   });
 

--- a/lib/job/manager.js
+++ b/lib/job/manager.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
+var NestedError = require('nested-error-stacks');
 
 var FileListener = require('./file-listener');
 var JobProcessor = require('./processor');
@@ -84,7 +85,7 @@ JobManager.prototype._readJobFile = function(filePath) {
       });
     })
     .catch(function(error) {
-      throw new Error('Invalid job file: ' + error.message)
+      throw new NestedError('Invalid job file', error)
     });
 };
 


### PR DESCRIPTION
Regarding this code:

```js
  Promise.map(services, function(service) {
    return service.start();
  }).catch(function(error) {
    serviceLocator.get('logger').error('Process failed. Exiting. ' + error.stack || error.message);
    process.emit('close');
  });

  process.on('unhandledRejection', function(reason) {
    serviceLocator.get('logger').error('Unexpected rejection error. ' + reason.stack || reason.message);
  });

  process.on('uncaughtException', function(err) {
    serviceLocator.get('logger').error('Unexpected runtime error. Shutdown the process ' + err.stack || err.message);
    process.emit('close');
  });
```