### PR TITLE
Introduce JanusCluster service for redirection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var NestedError = require('nested-error-stacks');
 var serviceLocator = require('./service-locator');
 var CMApiClient = require('./cm-api-client');
 var JanusHttpClient = require('./janus/http-client');
+var JanusCluster = require('./janus/cluster');
 var Streams = require('./streams');
 var CmApplication = require('./cm-application');
 
@@ -66,6 +67,10 @@ Application.prototype.registerServices = function() {
   serviceLocator.register('streams', function() {
     return new Streams();
   });
+
+  serviceLocator.register('janus-cluster', function() {
+    return new JanusCluster(this.config['janus-cluster']['httpAddress']);
+  }.bind(this));
 
   serviceLocator.register('cm-application', function() {
     return new CmApplication(this.config['cmApplication']['path']);

--- a/lib/janus/cluster.js
+++ b/lib/janus/cluster.js
@@ -1,0 +1,15 @@
+
+/**
+ * @param {String} address
+ * @constructor
+ */
+function JanusCluster(address) {
+  this.address = address;
+}
+
+JanusCluster.prototype.getEdgeAddress = function() {
+  // do http call to cluster service (simple http service with `http://janus-cluster/get-edge-address` endpoint)
+  return 'ws://edge-address';
+};
+
+module.exports = JanusCluster;

--- a/lib/janus/cluster.js
+++ b/lib/janus/cluster.js
@@ -1,6 +1,7 @@
 var requestPromise = require('request-promise');
 var serviceLocator = require('./../service-locator');
 var NestedError = require('nested-error-stacks');
+var Context = require('../context');
 
 /**
  * @param {String} baseUrl
@@ -30,7 +31,7 @@ JanusCluster.prototype._request = function(action, data) {
     options.body = data;
   }
 
-  serviceLocator.get('logger').info('janus-cluster', 'request', options.uri, options.body);
+  serviceLocator.get('logger').info('janus-cluster request', new Context({httpRequest: options}));
   return this._requestPromise(options)
     .catch(function(error) {
       throw new NestedError('janus-cluster error', error);

--- a/lib/janus/cluster.js
+++ b/lib/janus/cluster.js
@@ -1,15 +1,42 @@
+var requestPromise = require('request-promise');
+var serviceLocator = require('./../service-locator');
+var NestedError = require('nested-error-stacks');
 
 /**
- * @param {String} address
+ * @param {String} baseUrl
  * @constructor
  */
-function JanusCluster(address) {
-  this.address = address;
+function JanusCluster(baseUrl) {
+  this.baseUrl = baseUrl;
 }
 
 JanusCluster.prototype.getEdgeAddress = function() {
-  // do http call to cluster service (simple http service with `http://janus-cluster/get-edge-address` endpoint)
-  return 'ws://edge-address';
+  return this._request('/get-edge-address');
 };
+
+/**
+ * @param {String} action
+ * @param {Object} [data]
+ * @returns {Promise}
+ * @private
+ */
+JanusCluster.prototype._request = function(action, data) {
+  action = action || '/';
+  var options = {
+    method: 'POST',
+    uri: this.baseUrl + action
+  };
+  if (data) {
+    options.body = data;
+  }
+
+  serviceLocator.get('logger').info('janus-cluster', 'request', options.uri, options.body);
+  return this._requestPromise(options)
+    .catch(function(error) {
+      throw new NestedError('janus-cluster error', error);
+    })
+};
+
+JanusCluster.prototype._requestPromise = requestPromise;
 
 module.exports = JanusCluster;

--- a/lib/janus/cluster.js
+++ b/lib/janus/cluster.js
@@ -11,7 +11,7 @@ function JanusCluster(baseUrl) {
 }
 
 JanusCluster.prototype.getEdgeAddress = function() {
-  return this._request('/get-edge-address');
+  return this._request('/rtpbroadcast/edge-server');
 };
 
 /**

--- a/lib/janus/plugin/abstract.js
+++ b/lib/janus/plugin/abstract.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var Promise = require('bluebird');
 var serviceLocator = require('../../service-locator');
 var Context = require('../../context');

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -152,13 +152,6 @@ JanusProxy.prototype.handleError = function(error, fromClientConnection, transac
 /**
  * @returns {WebSocket.Server}
  */
-JanusProxy.prototype.openWebSocket = function() {
-  return new WebSocket(this.janusAddress, 'janus-protocol');
-};
-
-/**
- * @returns {WebSocket.Server}
- */
 JanusProxy.prototype.getWebSocketServer = function() {
   var webSocketServer = new WebSocket.Server({port: this.port});
   serviceLocator.get('logger').debug('WebSocket server on port ' + this.port + ' started');

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -29,33 +29,35 @@ JanusProxy.prototype.start = function() {
       serviceLocator.get('logger').warn('Can\'t remove streams on startup', error);
     })
     .then(function() {
-      // WebSocket server should listen on multiple endpoints, if it's not possible we should create 2 websocket servers
       var webSocketServer = proxy.getWebSocketServer();
-
-      webSocketServer.on('connection', function(incomingConnection) {
-        try {
-          var outgoingAddress = proxy.janusAddress;
-          if (incomingConnection.url.match('/\/edge$/')) {
-            outgoingAddress = serviceLocator.get('cluster').getEdgeConnectionAddress();
-          }
-          var outgoingConnection = new WebSocket(outgoingAddress, 'janus-protocol');
-          var fromClientConnection = new Connection('browser', incomingConnection);
-          var toJanusConnection = new Connection('janus', outgoingConnection);
-          proxy.establishConnection(fromClientConnection, toJanusConnection);
-
-        } catch (error) {
-          serviceLocator.get('logger').error('Unexpected JanusProxy runtime error: ' + error);
-          if (fromClientConnection) {
-            fromClientConnection.close();
-          }
-          if (toJanusConnection) {
-            toJanusConnection.close();
-          }
-        }
+      webSocketServer.on('connection/edge', function(incomingConnection) {
+        serviceLocator.get('cluster').getEdgeAddress()
+          .then(function(edgeAddress) {
+            proxy._wrapIntoConnections(edgeAddress, incomingConnection);
+          });
+      });
+      webSocketServer.on('connection/origin', function(incomingConnection) {
+        proxy._wrapIntoConnections(proxy.janusAddress, incomingConnection);
       });
     });
 };
 
+JanusProxy.prototype._wrapIntoConnections = function(outgoingAddress, incomingConnection) {
+  try {
+    var outgoingConnection = new WebSocket(outgoingAddress, 'janus-protocol');
+    var fromClientConnection = new Connection('browser', incomingConnection);
+    var toJanusConnection = new Connection('janus', outgoingConnection);
+    this.establishConnection(fromClientConnection, toJanusConnection);
+  } catch (error) {
+    serviceLocator.get('logger').error('Unexpected JanusProxy runtime error: ' + error);
+    if (fromClientConnection) {
+      fromClientConnection.close();
+    }
+    if (toJanusConnection) {
+      toJanusConnection.close();
+    }
+  }
+};
 /**
  * @param {Connection} fromClientConnection
  * @param {Connection} toJanusConnection

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -1,5 +1,8 @@
 var _ = require('underscore');
-var WebSocket = require('ws');
+var url = require('url');
+var http = require('http');
+var WebSocketClient = require('ws');
+var WebSocketServer = require('ws').Server;
 var uuid = require('node-uuid');
 var Promise = require('bluebird');
 
@@ -30,21 +33,26 @@ JanusProxy.prototype.start = function() {
     })
     .then(function() {
       var webSocketServer = proxy.getWebSocketServer();
-      webSocketServer.on('connection/edge', function(incomingConnection) {
-        serviceLocator.get('cluster').getEdgeAddress()
-          .then(function(edgeAddress) {
-            proxy._wrapIntoConnections(edgeAddress.webSocketAddress, incomingConnection);
-          });
-      });
-      webSocketServer.on('connection/origin', function(incomingConnection) {
-        proxy._wrapIntoConnections(proxy.janusAddress, incomingConnection);
+      webSocketServer.on('connection', function(incomingConnection) {
+        var location = url.parse(incomingConnection.upgradeReq.url, true);
+        switch (location.path) {
+          case '/edge':
+            serviceLocator.get('cluster').getEdgeAddress()
+              .then(function(edgeAddress) {
+                proxy._wrapIntoConnections(edgeAddress.webSocketAddress, incomingConnection);
+              });
+            break;
+          case '/origin':
+            proxy._wrapIntoConnections(proxy.janusAddress, incomingConnection);
+            break;
+        }
       });
     });
 };
 
 JanusProxy.prototype._wrapIntoConnections = function(outgoingAddress, incomingConnection) {
   try {
-    var outgoingConnection = new WebSocket(outgoingAddress, 'janus-protocol');
+    var outgoingConnection = new WebSocketClient(outgoingAddress, 'janus-protocol');
     var fromClientConnection = new Connection('browser', incomingConnection);
     var toJanusConnection = new Connection('janus', outgoingConnection);
     this.establishConnection(fromClientConnection, toJanusConnection);
@@ -150,10 +158,16 @@ JanusProxy.prototype.handleError = function(error, fromClientConnection, transac
 };
 
 /**
- * @returns {WebSocket.Server}
+ * @returns {WebSocketServer}
  */
 JanusProxy.prototype.getWebSocketServer = function() {
-  var webSocketServer = new WebSocket.Server({port: this.port});
+  var server = http.createServer(function(request, response) {
+    response.writeHead(404);
+    response.end();
+  });
+  var webSocketServer = new WebSocketServer({server: server});
+  server.listen(this.port);
+
   serviceLocator.get('logger').debug('WebSocket server on port ' + this.port + ' started');
   return webSocketServer;
 };

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -33,7 +33,7 @@ JanusProxy.prototype.start = function() {
       webSocketServer.on('connection/edge', function(incomingConnection) {
         serviceLocator.get('cluster').getEdgeAddress()
           .then(function(edgeAddress) {
-            proxy._wrapIntoConnections(edgeAddress, incomingConnection);
+            proxy._wrapIntoConnections(edgeAddress.webSocketAddress, incomingConnection);
           });
       });
       webSocketServer.on('connection/origin', function(incomingConnection) {

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -34,7 +34,6 @@ JanusProxy.prototype.start = function() {
     })
     .then(function() {
       var webSocketServer = proxy.getWebSocketServer();
-
       webSocketServer.on('connection', function(incomingConnection) {
         var location = url.parse(incomingConnection.upgradeReq.url, true);
         switch (location.path) {

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -41,6 +41,10 @@ JanusProxy.prototype.start = function() {
             serviceLocator.get('cluster').getEdgeAddress()
               .then(function(edgeAddress) {
                 proxy._wrapIntoConnections(edgeAddress.webSocketAddress, incomingConnection);
+              })
+              .catch(function(error) {
+                serviceLocator.get('logger').error('Unexpected JanusProxy runtime error', new Context({exception: error}));
+                incomingConnection.terminate();
               });
             break;
           case '/origin':
@@ -158,7 +162,10 @@ JanusProxy.prototype.handleError = function(error, fromClientConnection, transac
       errorMessage.transaction = transaction;
     }
     fromClientConnection.send(errorMessage).catch(function(error) {
-      serviceLocator.get('logger').warn('Could not send an error janus message to client', new Context({errorMessage: errorMessage, exception: error}));
+      serviceLocator.get('logger').warn('Could not send an error janus message to client', new Context({
+        errorMessage: errorMessage,
+        exception: error
+      }));
     });
   }
 };

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -6,8 +6,8 @@ var WebSocketServer = require('ws').Server;
 var uuid = require('node-uuid');
 var Promise = require('bluebird');
 
-var Context = require('./../context');
-var Connection = require('./../connection');
+var Context = require('../context');
+var Connection = require('../connection');
 var JanusConnection = require('./connection');
 var JanusError = require('./error');
 var serviceLocator = require('./../service-locator');

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -29,11 +29,16 @@ JanusProxy.prototype.start = function() {
       serviceLocator.get('logger').warn('Can\'t remove streams on startup', error);
     })
     .then(function() {
+      // WebSocket server should listen on multiple endpoints, if it's not possible we should create 2 websocket servers
       var webSocketServer = proxy.getWebSocketServer();
 
       webSocketServer.on('connection', function(incomingConnection) {
         try {
-          var outgoingConnection = proxy.openWebSocket();
+          var outgoingAddress = proxy.janusAddress;
+          if (incomingConnection.url.match('/\/edge$/')) {
+            outgoingAddress = serviceLocator.get('cluster').getEdgeConnectionAddress();
+          }
+          var outgoingConnection = new WebSocket(outgoingAddress, 'janus-protocol');
           var fromClientConnection = new Connection('browser', incomingConnection);
           var toJanusConnection = new Connection('janus', outgoingConnection);
           proxy.establishConnection(fromClientConnection, toJanusConnection);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,4 @@
-var _ = require('underscore');
 var logLevels = require('log4js').levels;
-var Context = require('./context');
 
 function Logger(log4js) {
   this.log4js = log4js;

--- a/test/spec/janus/proxy.js
+++ b/test/spec/janus/proxy.js
@@ -40,7 +40,7 @@ describe('JanusProxy', function() {
       janusServer.on('connection', function() {
         done();
       });
-      new WebSocket('ws://localhost:' + proxy.port);
+      new WebSocket('ws://localhost:' + proxy.port + '/origin');
     });
   });
 

--- a/test/unit/janus/cluster.js
+++ b/test/unit/janus/cluster.js
@@ -65,7 +65,7 @@ describe('JanusCluster unit tests', function() {
 
   it('getEdgeAddress()', function(done) {
     sinon.stub(janusCluster, '_request', function(action) {
-      assert.equal(action, '/get-edge-address');
+      assert.equal(action, '/rtpbroadcast/edge-server');
       done();
     });
     janusCluster.getEdgeAddress();

--- a/test/unit/janus/cluster.js
+++ b/test/unit/janus/cluster.js
@@ -1,0 +1,74 @@
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var _ = require('underscore');
+var Promise = require('bluebird');
+require('../../helpers/globals');
+var JanusCluster = require('../../../lib/janus/cluster');
+
+describe.only('JanusCluster unit tests', function() {
+
+  this.timeout(1000);
+
+  var baseUrl = 'http://cm.dev';
+  var janusCluster;
+
+  beforeEach(function() {
+    janusCluster = new JanusCluster(baseUrl);
+  });
+
+  it('is created properly', function() {
+    assert.strictEqual(janusCluster.baseUrl, baseUrl, 'has proper baseUrl');
+  });
+
+  context('_request()', function() {
+    var action = '/foo';
+    var data = {};
+
+    it('resolves if _requestPromise resolves', function(done) {
+      sinon.stub(janusCluster, '_requestPromise', _.constant(Promise.resolve('success')));
+      janusCluster._request(action, data)
+        .then(function(result) {
+          assert.equal(result, 'success');
+          done();
+        })
+        .catch(done);
+    });
+
+    it('add context info to _requestPromise rejection', function(done) {
+      sinon.stub(janusCluster, '_requestPromise', function() {
+        return Promise.reject(new Error('error'));
+      });
+      janusCluster._request(action, data)
+        .then(function() {
+          done(new Error('Should be rejected'));
+        })
+        .catch(function(error) {
+          assert.include(error.message, 'janus-cluster');
+          done();
+        });
+    });
+
+    it('sends options correctly', function(done) {
+      sinon.stub(janusCluster, '_requestPromise', function(options) {
+        assert.deepEqual(options, {
+          method: 'POST',
+          uri: janusCluster.baseUrl + action,
+          body: {}
+        }, 'invoked with proper params');
+        done();
+        return Promise.resolve();
+      });
+      janusCluster._request(action, data);
+    });
+
+  });
+
+  it('getEdgeAddress()', function(done) {
+    sinon.stub(janusCluster, '_request', function(action) {
+      assert.equal(action, '/get-edge-address');
+      done();
+    });
+    janusCluster.getEdgeAddress();
+  });
+
+});

--- a/test/unit/janus/cluster.js
+++ b/test/unit/janus/cluster.js
@@ -5,7 +5,7 @@ var Promise = require('bluebird');
 require('../../helpers/globals');
 var JanusCluster = require('../../../lib/janus/cluster');
 
-describe.only('JanusCluster unit tests', function() {
+describe('JanusCluster unit tests', function() {
 
   this.timeout(1000);
 


### PR DESCRIPTION
- Introduce JanusCluster service (http client for http://github.com/cargomedia/janus-cluster)
- Use ClusterManager service (if provided) to redirect `/edge` endpoint
- Use origin address for non-edge endpoint