### PR TITLE
Error in job process broke the whole process

### DIFF
--- a/lib/job/model/audioroom-recording.js
+++ b/lib/job/model/audioroom-recording.js
@@ -33,8 +33,9 @@ AudioroomRecordingJob.prototype._run = function() {
 
   return this._tmpFilename('mp3')
     .then(function(mp3File) {
-      return self._audioConvert(wavFile, mp3File)
+      return Promise.resolve()
         .then(function() {
+          require('fs').accessSync('I do not exist!');
           return serviceLocator.get('cm-application').importMediaStreamArchive(channelUid, mp3File)
         })
         .then(function() {

--- a/test/spec/job/manager.js
+++ b/test/spec/job/manager.js
@@ -118,4 +118,25 @@ describe('JobManager', function() {
     });
   });
 
+  it.only('audio job bla bla', function(done) {
+    this.timeout(100000);
+    var AudioJob = require('../../../lib/job/model/audioroom-recording');
+    createLocalTmpDir().then(function(tmpDirPath) {
+      var manager = new JobManager(tmpDirPath, tempJobsDir, [new JobHandler(AudioJob, {})]);
+      manager.start();
+      createJobFile(tmpDirPath, {
+        plugin: AudioJob.getPlugin(),
+        event: AudioJob.getEvent(),
+        data: {
+          uid: '1',
+          audio: '/Users/vogdb/workspace/work/cm-janus/delete/sample.wav'
+        }
+      });
+      setTimeout(function(){
+        console.log('\n  JOB PROCESSING WAS NOT INTERRUPTED BY AN INVALID FILE\n');
+        done();
+      }, 5000);
+    });
+  });
+
 });


### PR DESCRIPTION
There is a claim that an error during the job processing kills cm-janus entirely :
```
2016-03-20 14:22:28.629 INFO - { [Error: spawn /bin/sh ENOENT]
  code: 'ENOENT',
  errno: 'ENOENT',
  syscall: 'spawn /bin/sh',
  path: '/bin/sh',
  cmd: '/bin/sh -c bin/cm media-streams import-archive sample_id sample.mp3' }
Error: spawn /bin/sh ENOENT
    at exports._errnoException (util.js:746:11)
    at Process.ChildProcess._handle.onexit (child_process.js:1057:32)
    at child_process.js:1151:20
    at process._tickCallback (node.js:355:11)
```

cc @njam @tomaszdurka