### PR TITLE
Errors from "CMApiClient.removeStream()" are not logged

### DIFF
--- a/lib/cm-api-client.js
+++ b/lib/cm-api-client.js
@@ -39,7 +39,6 @@ CMApiClient.prototype._request = function(action, data) {
   serviceLocator.get('logger').info('cm-api request', {options: options});
   return this._requestPromise(options)
     .catch(function(reason) {
-      reason.options.body.params = reason.options.body.params.toString();
       var options = reason.options;
       serviceLocator.get('logger').error('cm-api request failed', {
         error: reason.error,

--- a/lib/cm-api-client.js
+++ b/lib/cm-api-client.js
@@ -40,7 +40,7 @@ CMApiClient.prototype._request = function(action, data) {
   return this._requestPromise(options)
     .catch(function(reason) {
       var options = reason.options;
-      serviceLocator.get('logger').error('cm-api request failed', {
+      serviceLocator.get('logger').warn('cm-api request failed', {
         error: reason.error,
         options: {uri: options.method + ' ' + options.uri, rpc: options.body.method + ' [' + options.body.params + ']'}
       });
@@ -49,7 +49,7 @@ CMApiClient.prototype._request = function(action, data) {
     .then(function(response) {
       var error = response['error'];
       if (error) {
-        serviceLocator.get('logger').error('cm-api error response', {response: response});
+        serviceLocator.get('logger').warn('cm-api error response', {response: response});
         throw new JanusError.CmApi(error['type'] + '. ' + error['msg']);
       }
       serviceLocator.get('logger').debug('cm-api response', {response: response});

--- a/lib/cm-api-client.js
+++ b/lib/cm-api-client.js
@@ -38,16 +38,22 @@ CMApiClient.prototype._request = function(action, data) {
 
   serviceLocator.get('logger').info('cm-api request', {options: options});
   return this._requestPromise(options)
-    .catch(function(error) {
-      throw new JanusError.CmApi(error['message']);
+    .catch(function(reason) {
+      reason.options.body.params = reason.options.body.params.toString();
+      var options = reason.options;
+      serviceLocator.get('logger').error('cm-api request failed', {
+        error: reason.error,
+        options: {uri: options.method + ' ' + options.uri, rpc: options.body.method + ' [' + options.body.params + ']'}
+      });
+      throw new JanusError.CmApi(reason.message);
     })
     .then(function(response) {
       var error = response['error'];
       if (error) {
-        serviceLocator.get('logger').error('cm-api response', {response: response});
+        serviceLocator.get('logger').error('cm-api error response', {response: response});
         throw new JanusError.CmApi(error['type'] + '. ' + error['msg']);
       }
-      serviceLocator.get('logger').info('cm-api response', {response: response.body});
+      serviceLocator.get('logger').debug('cm-api response', {response: response});
       return response['success']['result'];
     });
 };

--- a/test/unit/cm-api-client.js
+++ b/test/unit/cm-api-client.js
@@ -64,12 +64,12 @@ describe('CmApiClient unit tests', function() {
 
     it('works with completely failed request', function(done) {
       var requestPromiseMock = sinon.stub(cmApiClient, '_requestPromise', function() {
-        return Promise.reject(new Error('request failed'));
+        return Promise.reject({options: {method: '', uri: '', body: {method: '', params: ''}}});
       });
 
       cmApiClient._request(action, sentData).catch(function(err) {
         assert.instanceOf(err, Error);
-        assert.strictEqual(err.message, 'cm-api error: request failed');
+        assert.include(err.message, 'cm-api error:');
         assert.isTrue(requestPromiseMock.calledOnce);
         done();
       });


### PR DESCRIPTION
Update from @vogdb. Depends on #225.

We've just experienced lots of calls to `rpc_removeStream()` in CM failing ([details](https://github.com/cargomedia/cm/issues/2115)).

I noticed that there were no errors logged in cm-janus about it.

Here's an example "removeStream":
https://cargomedia.loggly.com/search/?terms=&from=2016-04-02T15%3A54%3A03.407Z&until=2016-04-02T16%3A04%3A03.407Z&source_group=

I guess the next record is the response:
```json
{"level":"INFO","message":"cm-api","additionalMessages":["response",null]}
```

@tomaszdurka @vogdb can you check if we log API call errors correctly?