### PR TITLE
Change some "info" log records to "warning" or "error"

### DIFF
--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -126,7 +126,7 @@ JanusProxy.prototype.handleError = function(error, fromClientConnection, transac
     serviceLocator.get('logger').error('Unexpected proxy error. Closing proxy connection.', {error: error});
     fromClientConnection.close();
   } else {
-    serviceLocator.get('logger').info('Proxy error.', {error: error});
+    serviceLocator.get('logger').warn('Proxy error.', {error: error});
     var errorMessage = {
       janus: 'error',
       error: {

--- a/lib/job/manager.js
+++ b/lib/job/manager.js
@@ -56,19 +56,20 @@ JobManager.prototype.stop = function() {
  */
 JobManager.prototype._processJobFile = function(filePath) {
   var self = this;
+  var job;
   return self._readJobFile(filePath)
     .then(function(jobDescription) {
       var jobId = path.basename(filePath, '.json');
       var handler = self.handlerRegistry.get(jobDescription['plugin'], jobDescription['event']);
-      var job = handler.instantiateJob(jobId, jobDescription['data']);
+      job = handler.instantiateJob(jobId, jobDescription['data']);
       return self._processor.processUntilSuccessful(job);
     })
     .then(function() {
-      serviceLocator.get('logger').info('Removing job file', {filepath: filePath});
+      serviceLocator.get('logger').info('Removing job file', {filepath: filePath, job: job ? job.serialize() : ''});
       return fs.unlinkAsync(filePath);
     })
     .catch(function(error) {
-      serviceLocator.get('logger').error('Processing job file failed', {error: error});
+      serviceLocator.get('logger').error('Processing job file failed', {error: error, job: job ? job.serialize() : ''});
     });
 };
 

--- a/lib/job/manager.js
+++ b/lib/job/manager.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var path = require('path');
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
@@ -65,11 +66,11 @@ JobManager.prototype._processJobFile = function(filePath) {
       return self._processor.processUntilSuccessful(job);
     })
     .then(function() {
-      serviceLocator.get('logger').info('Removing job file', {filepath: filePath, job: job && job.serialize()});
+      serviceLocator.get('logger').info('Removing job file', _.extend({filepath: filePath}, job && job.serialize()));
       return fs.unlinkAsync(filePath);
     })
     .catch(function(error) {
-      serviceLocator.get('logger').error('Processing job file failed', {error: error, job: job && job.serialize()});
+      serviceLocator.get('logger').error('Processing job file failed', _.extend({error: error}, job && job.serialize()));
     });
 };
 

--- a/lib/job/manager.js
+++ b/lib/job/manager.js
@@ -65,11 +65,11 @@ JobManager.prototype._processJobFile = function(filePath) {
       return self._processor.processUntilSuccessful(job);
     })
     .then(function() {
-      serviceLocator.get('logger').info('Removing job file', {filepath: filePath, job: job ? job.serialize() : ''});
+      serviceLocator.get('logger').info('Removing job file', {filepath: filePath, job: job && job.serialize()});
       return fs.unlinkAsync(filePath);
     })
     .catch(function(error) {
-      serviceLocator.get('logger').error('Processing job file failed', {error: error, job: job ? job.serialize() : ''});
+      serviceLocator.get('logger').error('Processing job file failed', {error: error, job: job && job.serialize()});
     });
 };
 

--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var fs = require('fs');
 var path = require('path');
 var spawn = require('child-process-promise').spawn;
@@ -114,7 +115,7 @@ AbstractJob.prototype._runJobScript = function(commandText) {
     commandArgs = commandParts;
   }
 
-  serviceLocator.get('logger').debug('Starting job process', {command: commandText, job: this.serialize()});
+  serviceLocator.get('logger').debug('Starting job process', _.extend({command: commandText}, this.serialize()));
   var options = {
     cwd: this.getWorkingDirectory(),
     capture: ['stdout', 'stderr']
@@ -128,7 +129,7 @@ AbstractJob.prototype._runJobScript = function(commandText) {
       return result.stdout.toString();
     })
     .catch(function(error) {
-      serviceLocator.get('logger').warn('Failed job process', {command: commandText, job: self.serialize()});
+      serviceLocator.get('logger').warn('Failed job process', _.extend({command: commandText}, self.serialize()));
       throw error;
     })
     .finally(function() {

--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -97,6 +97,10 @@ AbstractJob.prototype.cleanup = function() {
   }
 };
 
+AbstractJob.prototype.serialize = function() {
+  return {job: this.id};
+};
+
 /**
  * @param {String} commandText
  * @returns {Promise}
@@ -110,7 +114,7 @@ AbstractJob.prototype._runJobScript = function(commandText) {
     commandArgs = commandParts;
   }
 
-  serviceLocator.get('logger').debug('Starting job process', {command: commandText});
+  serviceLocator.get('logger').debug('Starting job process', {command: commandText, job: this.serialize()});
   var options = {
     cwd: this.getWorkingDirectory(),
     capture: ['stdout', 'stderr']
@@ -124,7 +128,7 @@ AbstractJob.prototype._runJobScript = function(commandText) {
       return result.stdout.toString();
     })
     .catch(function(error) {
-      serviceLocator.get('logger').warn('Failed job process', {command: commandText});
+      serviceLocator.get('logger').warn('Failed job process', {command: commandText, job: self.serialize()});
       throw error;
     })
     .finally(function() {

--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -1,7 +1,6 @@
 var fs = require('fs');
 var path = require('path');
 var spawn = require('child-process-promise').spawn;
-var NestedError = require('nested-error-stacks');
 var Promise = require('bluebird');
 var tmpName = Promise.promisify(require('tmp').tmpName);
 var rimraf = require('rimraf');

--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -125,7 +125,7 @@ AbstractJob.prototype._runJobScript = function(commandText) {
       return result.stdout.toString();
     })
     .catch(function(error) {
-      serviceLocator.get('logger').debug('Failed job process', {command: commandText});
+      serviceLocator.get('logger').warn('Failed job process', {command: commandText});
       throw error;
     })
     .finally(function() {

--- a/lib/job/model/audioroom-recording.js
+++ b/lib/job/model/audioroom-recording.js
@@ -39,7 +39,7 @@ AudioroomRecordingJob.prototype._run = function() {
         })
         .then(function() {
           return unlink(wavFile).catch(function(error) {
-            serviceLocator.get('logger').error('Removing wave file failed', {error: error});
+            serviceLocator.get('logger').error('Removing wave file failed', {error: error, job: self.serialize()});
           });
         });
     });

--- a/lib/job/model/audioroom-recording.js
+++ b/lib/job/model/audioroom-recording.js
@@ -39,7 +39,7 @@ AudioroomRecordingJob.prototype._run = function() {
         })
         .then(function() {
           return unlink(wavFile).catch(function(error) {
-            serviceLocator.get('logger').error('Removing wave file failed', {error: error, job: self.serialize()});
+            serviceLocator.get('logger').error('Removing wave file failed', _.extend({error: error}, self.serialize()));
           });
         });
     });

--- a/lib/job/model/rtpbroadcast-recording.js
+++ b/lib/job/model/rtpbroadcast-recording.js
@@ -44,10 +44,10 @@ RtpbroadcastRecordingJob.prototype._run = function() {
         .then(function() {
           return Promise.join(
             unlink(audioMjrFile).catch(function(error) {
-              serviceLocator.get('logger').error('Removing audio file failed', {error: error, job: self.serialize()});
+              serviceLocator.get('logger').error('Removing audio file failed', _.extend({error: error}, self.serialize()));
             }),
             unlink(videoMjrFile).catch(function(error) {
-              serviceLocator.get('logger').error('Removing video file failed', {error: error, job: self.serialize()});
+              serviceLocator.get('logger').error('Removing video file failed', _.extend({error: error}, self.serialize()));
             })
           );
         });

--- a/lib/job/model/rtpbroadcast-recording.js
+++ b/lib/job/model/rtpbroadcast-recording.js
@@ -44,10 +44,10 @@ RtpbroadcastRecordingJob.prototype._run = function() {
         .then(function() {
           return Promise.join(
             unlink(audioMjrFile).catch(function(error) {
-              serviceLocator.get('logger').error('Removing audio file failed', {error: error});
+              serviceLocator.get('logger').error('Removing audio file failed', {error: error, job: self.serialize()});
             }),
             unlink(videoMjrFile).catch(function(error) {
-              serviceLocator.get('logger').error('Removing video file failed', {error: error});
+              serviceLocator.get('logger').error('Removing video file failed', {error: error, job: self.serialize()});
             })
           );
         });

--- a/lib/job/model/rtpbroadcast-thumbnail.js
+++ b/lib/job/model/rtpbroadcast-thumbnail.js
@@ -43,7 +43,7 @@ RtpbroadcastThumbnailJob.prototype._run = function() {
         })
         .then(function() {
           return unlink(videoMjrFile).catch(function(error) {
-            serviceLocator.get('logger').error('Removing thumbnail video file failed', {error: error});
+            serviceLocator.get('logger').error('Removing thumbnail video file failed', {error: error, job: self.serialize()});
           });
         });
     });

--- a/lib/job/model/rtpbroadcast-thumbnail.js
+++ b/lib/job/model/rtpbroadcast-thumbnail.js
@@ -43,7 +43,7 @@ RtpbroadcastThumbnailJob.prototype._run = function() {
         })
         .then(function() {
           return unlink(videoMjrFile).catch(function(error) {
-            serviceLocator.get('logger').error('Removing thumbnail video file failed', {error: error, job: self.serialize()});
+            serviceLocator.get('logger').error('Removing thumbnail video file failed', _.extend({error: error}, self.serialize()));
           });
         });
     });

--- a/lib/job/processor.js
+++ b/lib/job/processor.js
@@ -64,7 +64,7 @@ JobProcessor.prototype.process = function(job) {
 JobProcessor.prototype.processUntilSuccessful = function(job) {
   var self = this;
   return this.process(job).catch(function(error) {
-    serviceLocator.get('logger').info('Job processing failed. Reattempt.', {error: error});
+    serviceLocator.get('logger').warn('Job processing failed. Reattempt.', {error: error});
     return Promise.delay(self._retyDelay).then(function() {
       return self.processUntilSuccessful(job);
     })

--- a/lib/job/processor.js
+++ b/lib/job/processor.js
@@ -64,7 +64,7 @@ JobProcessor.prototype.process = function(job) {
 JobProcessor.prototype.processUntilSuccessful = function(job) {
   var self = this;
   return this.process(job).catch(function(error) {
-    serviceLocator.get('logger').warn('Job processing failed. Reattempt.', {error: error});
+    serviceLocator.get('logger').warn('Job processing failed. Reattempt.', {error: error, job: job.serialize()});
     return Promise.delay(self._retyDelay).then(function() {
       return self.processUntilSuccessful(job);
     })
@@ -97,7 +97,7 @@ JobProcessor.prototype._createJobWorkingDirectory = function(job) {
     fs.accessSync(dir, fs.W_OK);
   }
   catch (err) {
-    serviceLocator.get('logger').error('Job working directory could not be created');
+    serviceLocator.get('logger').error('Job working directory could not be created', {job: job.serialize()});
     throw err;
   }
   return dir;

--- a/lib/job/processor.js
+++ b/lib/job/processor.js
@@ -97,7 +97,7 @@ JobProcessor.prototype._createJobWorkingDirectory = function(job) {
     fs.accessSync(dir, fs.W_OK);
   }
   catch (err) {
-    serviceLocator.get('logger').error('Job working directory could not be created', job.serialize());
+    serviceLocator.get('logger').error('Job working directory could not be created', _.extend({error: err}, job.serialize()));
     throw err;
   }
   return dir;

--- a/lib/job/processor.js
+++ b/lib/job/processor.js
@@ -64,7 +64,7 @@ JobProcessor.prototype.process = function(job) {
 JobProcessor.prototype.processUntilSuccessful = function(job) {
   var self = this;
   return this.process(job).catch(function(error) {
-    serviceLocator.get('logger').warn('Job processing failed. Reattempt.', {error: error, job: job.serialize()});
+    serviceLocator.get('logger').warn('Job processing failed. Reattempt.', _.extend({error: error}, job.serialize()));
     return Promise.delay(self._retyDelay).then(function() {
       return self.processUntilSuccessful(job);
     })
@@ -97,7 +97,7 @@ JobProcessor.prototype._createJobWorkingDirectory = function(job) {
     fs.accessSync(dir, fs.W_OK);
   }
   catch (err) {
-    serviceLocator.get('logger').error('Job working directory could not be created', {job: job.serialize()});
+    serviceLocator.get('logger').error('Job working directory could not be created', job.serialize());
     throw err;
   }
   return dir;


### PR DESCRIPTION
Whenever something bad/unexpected happens it should be "warning" or "error".

E.g. this should be "warning":
```
{"level":"info","error":{"code":1,"message":"`ionice -c 2 -n 7 nice
```

cc @tomaszdurka