### PR TITLE
Reduce number of (debug) log events

### DIFF
--- a/lib/cm-api-client.js
+++ b/lib/cm-api-client.js
@@ -36,10 +36,8 @@ CMApiClient.prototype._request = function(action, data) {
     json: true
   };
 
-  serviceLocator.get('logger').info('cm-api request', {options: options});
   return this._requestPromise(options)
     .catch(function(reason) {
-      var options = reason.options;
       serviceLocator.get('logger').warn('cm-api request failed', {
         error: reason.error,
         options: {uri: options.method + ' ' + options.uri, rpc: options.body.method + ' [' + options.body.params + ']'}
@@ -49,10 +47,13 @@ CMApiClient.prototype._request = function(action, data) {
     .then(function(response) {
       var error = response['error'];
       if (error) {
-        serviceLocator.get('logger').warn('cm-api error response', {response: response});
+        serviceLocator.get('logger').warn('cm-api error response', {
+          response: response,
+          options: {uri: options.method + ' ' + options.uri, rpc: options.body.method + ' [' + options.body.params + ']'}
+        });
         throw new JanusError.CmApi(error['type'] + '. ' + error['msg']);
       }
-      serviceLocator.get('logger').debug('cm-api response', {response: response});
+      serviceLocator.get('logger').debug('cm-api call', {request: options, response: response});
       return response['success']['result'];
     });
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -4,9 +4,6 @@ var WebSocket = require('ws');
 var util = require('util');
 var url = require('url');
 
-var serviceLocator = require('./service-locator');
-
-
 /**
  * @param {String} identifier
  * @param {WebSocket} webSocket
@@ -17,11 +14,8 @@ function Connection(identifier, webSocket) {
 
   this.webSocket = webSocket;
   this.webSocket.on('message', function(data) {
-    var message;
     try {
-      message = JSON.parse(data);
-      serviceLocator.get('logger').debug('<- ' + this.identifier, {request: message});
-      this._onMessage(message);
+      this._onMessage(JSON.parse(data));
     } catch (error) {
       this.emit('error', error);
     }
@@ -83,7 +77,6 @@ Connection.prototype._queue = function(message) {
  * @private
  */
 Connection.prototype._send = function(message) {
-  serviceLocator.get('logger').debug('-> ' + this.identifier, {request: message});
   return new Promise(function(resolve, reject) {
     this.webSocket.send(JSON.stringify(message), {}, function(err) {
       if (err) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -66,7 +66,7 @@ HttpServer.prototype.installRoutes = function(router) {
           return next();
         })
         .catch(function(error) {
-          serviceLocator.get('logger').warn('Stream stop failed. Removing stream by force.', context.clone().extend({error: error}));
+          serviceLocator.get('logger').warn('Detaching plugin failed', context.clone().extend({error: error}));
           stream.plugin.removeStream()
             .then(function() {
               res.send({error: 'Stream stop failed. Stream was removed by force.'});

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -42,7 +42,7 @@ HttpServer.prototype.installRoutes = function(router) {
   var self = this;
 
   router.use(function(req, res, next) {
-    serviceLocator.get('logger').debug('request ' + req.path);
+    serviceLocator.get('logger').debug('http-server request ' + req.path);
     var serverKey = req.get('Server-Key');
     if (!serverKey || serverKey !== self.apiKey) {
       res.sendStatus(403);
@@ -62,8 +62,7 @@ HttpServer.prototype.installRoutes = function(router) {
           return next();
         })
         .catch(function(error) {
-          serviceLocator.get('logger').warn('Stream stop failed', {error: error});
-          serviceLocator.get('logger').warn('Removing stream by force');
+          serviceLocator.get('logger').warn('Stream stop failed. Removing stream by force.', {error: error});
           stream.plugin.onRemove()
             .then(function() {
               res.send({error: 'Stream stop failed. Stream was removed by force.'});
@@ -100,7 +99,7 @@ HttpServer.prototype.start = function() {
         if (err) {
           reject(err);
         } else {
-          serviceLocator.get('logger').debug('HTTP server on port ' + self.port + ' started');
+          serviceLocator.get('logger').info('http-server on port ' + self.port + ' started');
           resolve();
         }
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,16 +91,16 @@ Application.prototype.start = function() {
   Promise.map(services, function(service) {
     return service.start();
   }).catch(function(error) {
-    serviceLocator.get('logger').error('Process failed. Exiting.', {error: error});
+    serviceLocator.get('logger').fatal('Process failed. Exiting.', {error: error});
     process.emit('close');
   });
 
   process.on('unhandledRejection', function(reason) {
-    serviceLocator.get('logger').error('Unexpected rejection error.', {error: reason});
+    serviceLocator.get('logger').fatal('Unexpected rejection error.', {error: reason});
   });
 
   process.on('uncaughtException', function(error) {
-    serviceLocator.get('logger').error('Unexpected runtime error. Shutdown the process.', {error: error});
+    serviceLocator.get('logger').fatal('Unexpected runtime error. Shutdown the process.', {error: error});
     process.emit('close');
   });
 

--- a/lib/janus/connection.js
+++ b/lib/janus/connection.js
@@ -61,7 +61,7 @@ JanusConnection.prototype.processMessage = function(message) {
   //This is an invalid case, so lets log all such messages
   var pluginId = message['sender'] || message['handle_id'] || null;
   if (pluginId) {
-    serviceLocator.get('logger').warn('Plugin message without session', {request: message});
+    serviceLocator.get('logger').error('Plugin message without session', {request: message});
     var session = _.find(this._sessions, function(session) {
       return !!session.plugins[pluginId];
     });

--- a/lib/janus/http-client.js
+++ b/lib/janus/http-client.js
@@ -25,13 +25,13 @@ JanusHttpClient.prototype._request = function(action, data) {
     options.body = data;
   }
 
-  serviceLocator.get('logger').info('http-client request', {options: options});
+  serviceLocator.get('logger').debug('http-client request', {options: options});
   return this._requestPromise(options)
     .catch(function(error) {
       throw new Error('http-client error: ' + error['message']);
     })
     .then(function(response) {
-      serviceLocator.get('logger').info('http-client response', {response: response});
+      serviceLocator.get('logger').debug('http-client response', {response: response});
       if ('error' == response['janus']) {
         throw new Error('http-client error: ' + response['error']['reason']);
       }

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -128,7 +128,7 @@ JanusProxy.prototype.handleError = function(error, fromClientConnection, transac
     serviceLocator.get('logger').error('Unexpected proxy error. Closing proxy connection.', {error: error});
     fromClientConnection.close();
   } else {
-    serviceLocator.get('logger').warn('Proxy error.', {error: error});
+    serviceLocator.get('logger').error('Proxy error', {error: error});
     var errorMessage = {
       janus: 'error',
       error: {

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -75,6 +75,7 @@ JanusProxy.prototype.establishConnection = function(fromClientConnection, toJanu
   };
 
   fromClientConnection.on('message', function(request) {
+    serviceLocator.get('logger').debug('proxying browser -> janus', {request: request});
     connection.processMessage(request)
       .then(function(processedRequest) {
         toJanusConnection.send(processedRequest);
@@ -85,6 +86,7 @@ JanusProxy.prototype.establishConnection = function(fromClientConnection, toJanu
   });
 
   toJanusConnection.on('message', function(request) {
+    serviceLocator.get('logger').debug('proxying janus -> browser', {request: request});
     connection.processMessage(request)
       .then(function(processedRequest) {
         fromClientConnection.send(processedRequest);

--- a/lib/job/manager.js
+++ b/lib/job/manager.js
@@ -66,7 +66,7 @@ JobManager.prototype._processJobFile = function(filePath) {
       return self._processor.processUntilSuccessful(job);
     })
     .then(function() {
-      serviceLocator.get('logger').info('Removing job file', _.extend({filepath: filePath}, job && job.getContext()));
+      serviceLocator.get('logger').debug('Removing job file', _.extend({filepath: filePath}, job && job.getContext()));
       return fs.unlinkAsync(filePath);
     })
     .catch(function(error) {

--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -133,7 +133,7 @@ AbstractJob.prototype._runJobScript = function(commandText) {
       return result.stdout.toString();
     })
     .catch(function(error) {
-      serviceLocator.get('logger').warn('Failed job process', _.extend({command: commandText}, self.getContext()));
+      serviceLocator.get('logger').error('Failed job process', _.extend({command: commandText}, self.getContext()));
       throw error;
     })
     .finally(function() {


### PR DESCRIPTION
Currently 50'000 events per hour => ~14 events per second.

![screen shot 2016-04-05 at 10 18 17](https://cloud.githubusercontent.com/assets/360800/14275488/bbf4e0c4-fb17-11e5-9495-4a762577dc1d.png)


Ideas:
- Combine debug records for the same transaction over some time? (instead of "-> browser", "-> janus" etc all separate?)
- What else?