### PR TITLE
Fix HttpClient.detach usages

### DIFF
--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -54,7 +54,9 @@ PluginStreaming.prototype.subscribe = function() {
     });
   }))
     .catch(JanusError.Error, function(error) {
-      serviceLocator.get('http-client').detach(plugin);
+      serviceLocator.get('http-client').detach(plugin).catch(function() {
+        serviceLocator.get('logger').warn('Failed detach of plugin', plugin.getContext());
+      });
       throw new JanusError.Error('Cannot subscribe: ' + stream + ' for ' + plugin + 'error: ' + error.message, 490);
     });
 };
@@ -71,7 +73,9 @@ PluginStreaming.prototype.publish = function() {
     });
   }))
     .catch(JanusError.Error, function(error) {
-      serviceLocator.get('http-client').detach(plugin);
+      serviceLocator.get('http-client').detach(plugin).catch(function() {
+        serviceLocator.get('logger').warn('Failed detach of plugin', plugin.getContext());
+      });
       throw new JanusError.Error('Cannot publish: ' + stream + ' for ' + plugin + ' error: ' + error.message, 490);
     });
 };

--- a/lib/janus/plugin/streaming.js
+++ b/lib/janus/plugin/streaming.js
@@ -54,8 +54,8 @@ PluginStreaming.prototype.subscribe = function() {
     });
   }))
     .catch(JanusError.Error, function(error) {
-      serviceLocator.get('http-client').detach(plugin).catch(function() {
-        serviceLocator.get('logger').warn('Failed detach of plugin', plugin.getContext());
+      serviceLocator.get('http-client').detach(plugin).catch(function(error) {
+        serviceLocator.get('logger').warn('Failed detach of plugin', plugin.getContext().extend({error: error}));
       });
       throw new JanusError.Error('Cannot subscribe: ' + stream + ' for ' + plugin + 'error: ' + error.message, 490);
     });
@@ -73,8 +73,8 @@ PluginStreaming.prototype.publish = function() {
     });
   }))
     .catch(JanusError.Error, function(error) {
-      serviceLocator.get('http-client').detach(plugin).catch(function() {
-        serviceLocator.get('logger').warn('Failed detach of plugin', plugin.getContext());
+      serviceLocator.get('http-client').detach(plugin).catch(function(error) {
+        serviceLocator.get('logger').warn('Failed detach of plugin', plugin.getContext().extend({error: error}));
       });
       throw new JanusError.Error('Cannot publish: ' + stream + ' for ' + plugin + ' error: ' + error.message, 490);
     });

--- a/test/spec/janus/plugin/streaming.js
+++ b/test/spec/janus/plugin/streaming.js
@@ -61,6 +61,7 @@ describe('PluginStreaming', function() {
     context('on unsuccessful subscribe', function() {
       beforeEach(function() {
         streams.addSubscribe.restore();
+        httpClient.detach.returns(Promise.resolve());
         sinon.stub(streams, 'addSubscribe', function() {
           return Promise.reject(new JanusError.Error('Cannot subscribe'));
         });


### PR DESCRIPTION
```
json:
timestamp: 2016-04-06T12:27:54+00:00
message: Unexpected rejection error.
hostname: janus2.fuckbook.com
level: error
error:
message: http-client error: No such session 1942071661
stack:
Error: http-client error: No such session 1942071661
    at /usr/lib/node_modules/cm-janus/lib/janus/http-client.js:36:15
    at tryCatcher (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromises (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:697:14)
    at Async._drainQueue (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:367:17)
```