### PR TITLE
Cannot read property 'error' of undefined

### DIFF
--- a/lib/cm-api-client.js
+++ b/lib/cm-api-client.js
@@ -47,6 +47,10 @@ CMApiClient.prototype._request = function(action, data) {
       throw new JanusError.CmApi(reason.message);
     })
     .then(function(response) {
+      if (!response || (!response['error'] && !response['success'])) {
+        serviceLocator.get('logger').error('cm-api unexpected response', {response: response});
+        throw new JanusError.CmApi('Unexpected response format');
+      }
       var error = response['error'];
       if (error) {
         serviceLocator.get('logger').warn('cm-api error response', {response: response});

--- a/test/unit/cm-api-client.js
+++ b/test/unit/cm-api-client.js
@@ -75,6 +75,21 @@ describe('CmApiClient unit tests', function() {
       });
       requestPromiseMock.restore();
     });
+
+    it('fails for unexpected format request', function(done) {
+      var requestPromiseMock = sinon.stub(cmApiClient, '_requestPromise', function() {
+        return Promise.resolve('');
+      });
+
+      cmApiClient._request(action, sentData).catch(function(err) {
+        assert.instanceOf(err, Error);
+        assert.include(err.message, 'cm-api error:');
+        assert.isTrue(requestPromiseMock.calledOnce);
+        done();
+      });
+      requestPromiseMock.restore();
+    });
+
   });
 
   describe('publish()', function() {


### PR DESCRIPTION
I guess this should not happen?
```
TypeError: Cannot read property 'error' of undefined
    at /usr/lib/node_modules/cm-janus/lib/cm-api-client.js:50:27
    at tryCatcher (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromises (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/promise.js:697:14)
    at Async._drainQueue (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/usr/lib/node_modules/cm-janus/node_modules/request-promise/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:367:17)
```