### PR TITLE
Loggly Alert: cm-janus fatal error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,9 +98,9 @@ Application.prototype.start = function() {
 
   process.on('unhandledRejection', function(reason) {
     if ('This socket has been ended by the other party' == reason.message) {
-      serviceLocator.get('logger').warn('Expected rejection error', new Context({exception: reason}));
+      serviceLocator.get('logger').warn('Expected rejection error.', new Context({exception: reason}));
     } else {
-      serviceLocator.get('logger').fatal('Unexpected rejection error', new Context({exception: reason}));
+      serviceLocator.get('logger').fatal('Unexpected rejection error.', new Context({exception: reason}));
     }
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,11 +97,7 @@ Application.prototype.start = function() {
   });
 
   process.on('unhandledRejection', function(reason) {
-    if ('This socket has been ended by the other party' == reason.message) {
-      serviceLocator.get('logger').warn('Expected rejection error.', new Context({exception: reason}));
-    } else {
-      serviceLocator.get('logger').fatal('Unexpected rejection error.', new Context({exception: reason}));
-    }
+    serviceLocator.get('logger').fatal('Unexpected rejection error.', new Context({exception: reason}));
   });
 
   process.on('uncaughtException', function(error) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,11 @@ Application.prototype.start = function() {
   });
 
   process.on('unhandledRejection', function(reason) {
-    serviceLocator.get('logger').fatal('Unexpected rejection error.', new Context({exception: reason}));
+    if ('This socket has been ended by the other party' == reason.message) {
+      serviceLocator.get('logger').warn('Expected rejection error.', new Context({exception: reason}));
+    } else {
+      serviceLocator.get('logger').fatal('Unexpected rejection error.', new Context({exception: reason}));
+    }
   });
 
   process.on('uncaughtException', function(error) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,9 +98,9 @@ Application.prototype.start = function() {
 
   process.on('unhandledRejection', function(reason) {
     if ('This socket has been ended by the other party' == reason.message) {
-      serviceLocator.get('logger').warn('Expected rejection error.', new Context({exception: reason}));
+      serviceLocator.get('logger').warn('Expected rejection error', new Context({exception: reason}));
     } else {
-      serviceLocator.get('logger').fatal('Unexpected rejection error.', new Context({exception: reason}));
+      serviceLocator.get('logger').fatal('Unexpected rejection error', new Context({exception: reason}));
     }
   });
 

--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -141,7 +141,9 @@ JanusProxy.prototype.handleError = function(error, fromClientConnection, transac
     if (transaction) {
       errorMessage.transaction = transaction;
     }
-    fromClientConnection.send(errorMessage);
+    fromClientConnection.send(errorMessage).catch(function(error) {
+      serviceLocator.get('logger').warn('Could not send an error janus message to client', new Context({errorMessage: errorMessage, exception: error}));
+    });
   }
 };
 


### PR DESCRIPTION
https://cargomedia.loggly.com/search/?terms=tag%3Acm-janus+AND+json.level%3Afatal&source_group=&savedsearchid=206843&from=2016-04-27T13%3A49%3A38Z&until=2016-04-27T13%3A54%3A38Z

```
{"level":"fatal","message":"Unexpected rejection error.","exception":{"type":"Error","message":"This socket has been ended by the other party","stack":"Error: This socket has been ended by the other party
    at Socket.writeAfterFIN [as write] (net.js:284:12)
    at Sender.frameAndSend (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Sender.js:232:22)
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/Sender.js:126:12
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/PerMessageDeflate.js:313:5
    at afterWrite (_stream_writable.js:354:3)
    at onwrite (_stream_writable.js:345:7)
    at WritableState.onwrite (_stream_writable.js:89:5)
    at afterTransform (_stream_transform.js:79:3)
    at TransformState.afterTransform (_stream_transform.js:54:12)
    at Zlib.callback (zlib.js:623:5)"},"hostname":"janus2.fuckbook.com","timestamp":"2016-04-27T13:54:01+00:00"}
```