### PR TITLE
Loggly Alert: cm-janus fatal error

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -64,9 +64,13 @@ Connection.prototype._queue = function(message) {
   var self = this;
   return new Promise(function(resolve) {
     self.webSocket.once('open', function() {
-      self._send(message).then(function(response) {
-        resolve(response);
-      });
+      self._send(message)
+        .then(function(response) {
+          resolve(response);
+        })
+        .catch(function(error) {
+          self.emit('error', error);
+        });
     });
   });
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -62,14 +62,14 @@ Connection.prototype.isOpened = function() {
  */
 Connection.prototype._queue = function(message) {
   var self = this;
-  return new Promise(function(resolve) {
+  return new Promise(function(resolve, reject) {
     self.webSocket.once('open', function() {
       self._send(message)
         .then(function(response) {
           resolve(response);
         })
         .catch(function(error) {
-          self.emit('error', error);
+          reject(error);
         });
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cm-janus",
   "description": "",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "",


### PR DESCRIPTION
https://cargomedia.loggly.com/search/?terms=tag%3Acm-janus+AND+json.level%3Afatal&source_group=&savedsearchid=206843&from=2016-04-30T14%3A47%3A32Z&until=2016-04-30T14%3A52%3A32Z

```
{"level":"fatal","message":"Unexpected rejection error.","exception":{"type":"Error","message":"This socket has been ended by the other party","stack":"Error: This socket has been ended by the other party
    at Socket.writeAfterFIN [as write] (net.js:284:12)
    at Sender.frameAndSend (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Sender.js:232:22)
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/Sender.js:126:12
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/PerMessageDeflate.js:313:5
    at afterWrite (_stream_writable.js:354:3)
    at onwrite (_stream_writable.js:345:7)
    at WritableState.onwrite (_stream_writable.js:89:5)
    at afterTransform (_stream_transform.js:79:3)
    at TransformState.afterTransform (_stream_transform.js:54:12)
    at Zlib.callback (zlib.js:623:5)"},"hostname":"janus2.fuckbook.com","timestamp":"2016-04-30T14:50:46+00:00"}
```