### PR TITLE
Improve http server requests' logging

### DIFF
--- a/lib/cm-api-client.js
+++ b/lib/cm-api-client.js
@@ -56,10 +56,6 @@ CMApiClient.prototype._request = function(action, data, context) {
       throw new JanusError.CmApi(reason.message);
     })
     .then(function(response) {
-      if (response['context']) {
-        requestContext.extend(response['context']);
-        delete response['context'];
-      }
       requestContext.extend({janus: {response: response}});
       if (!response || (!response['error'] && !response['success'])) {
         serviceLocator.get('logger').error('cm-api unexpected response', requestContext);

--- a/lib/cm-api-client.js
+++ b/lib/cm-api-client.js
@@ -56,6 +56,10 @@ CMApiClient.prototype._request = function(action, data, context) {
       throw new JanusError.CmApi(reason.message);
     })
     .then(function(response) {
+      if (response['context']) {
+        requestContext.extend(response['context']);
+        delete response['context'];
+      }
       requestContext.extend({janus: {response: response}});
       if (!response || (!response['error'] && !response['success'])) {
         serviceLocator.get('logger').error('cm-api unexpected response', requestContext);

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -44,7 +44,7 @@ HttpServer.prototype.installRoutes = function(router) {
   var self = this;
 
   router.use(function(req, res, next) {
-    serviceLocator.get('logger').debug('http-server request ' + req.path);
+    serviceLocator.get('logger').info('http-server request ' + req.path);
     var serverKey = req.get('Server-Key');
     if (!serverKey || serverKey !== self.apiKey) {
       res.sendStatus(403);

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -60,6 +60,9 @@ HttpServer.prototype.installRoutes = function(router) {
     var stream = serviceLocator.get('streams').find(streamId);
     if (stream) {
       context.merge(stream.getContext());
+      if (params['context']) {
+        context.extend(params['context']);
+      }
       serviceLocator.get('http-client').detach(stream.plugin)
         .then(function() {
           res.send({success: 'Stream stopped'});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cm-janus",
   "description": "",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "",


### PR DESCRIPTION
- intercept context-data sent from CM application (similar to websocket)
- change level from `debug` to `info` (https://github.com/cargomedia/cm-janus/blob/ceef69f6ff34e1db4077567a29e3acabd1676fe9/lib/http-server.js#L47)