### PR TITLE
Loggly Alert: cm-janus fatal

### DIFF
--- a/lib/janus/proxy.js
+++ b/lib/janus/proxy.js
@@ -79,7 +79,7 @@ JanusProxy.prototype.establishConnection = function(fromClientConnection, toJanu
     serviceLocator.get('logger').debug('proxying browser -> janus', connection.getContext().extend({janus: {request: request}}));
     connection.processMessage(request)
       .then(function(processedRequest) {
-        toJanusConnection.send(processedRequest);
+        return toJanusConnection.send(processedRequest);
       })
       .catch(function(error) {
         handleError(error, request['transaction']);
@@ -90,7 +90,7 @@ JanusProxy.prototype.establishConnection = function(fromClientConnection, toJanu
     serviceLocator.get('logger').debug('proxying janus -> browser', connection.getContext().extend({janus: {request: request}}));
     connection.processMessage(request)
       .then(function(processedRequest) {
-        fromClientConnection.send(processedRequest);
+        return fromClientConnection.send(processedRequest);
       })
       .catch(function(error) {
         handleError(error, request ? request['transaction'] : null);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cm-janus",
   "description": "",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "",


### PR DESCRIPTION
https://cargomedia.loggly.com/search/?terms=tag%3Acm-janus+AND+json.level%3Afatal&source_group=&savedsearchid=206843&from=2016-05-04T19%3A14%3A54Z&until=2016-05-04T19%3A19%3A54Z

```
{"level":"fatal","message":"Unexpected rejection error.","exception":{"type":"Error","message":"This socket has been ended by the other party","stack":"Error: This socket has been ended by the other party
    at Socket.writeAfterFIN [as write] (net.js:284:12)
    at Sender.frameAndSend (/usr/lib/node_modules/cm-janus/node_modules/ws/lib/Sender.js:232:22)
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/Sender.js:126:12
    at /usr/lib/node_modules/cm-janus/node_modules/ws/lib/PerMessageDeflate.js:313:5
    at afterWrite (_stream_writable.js:354:3)
    at onwrite (_stream_writable.js:345:7)
    at WritableState.onwrite (_stream_writable.js:89:5)
    at afterTransform (_stream_transform.js:79:3)
    at TransformState.afterTransform (_stream_transform.js:54:12)
    at Zlib.callback (zlib.js:623:5)"},"hostname":"janus2.fuckbook.com","timestamp":"2016-05-04T19:19:20+00:00"}
```