### PR TITLE
Include "retryCount" in job processing error

### DIFF
--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -35,6 +35,9 @@ function AbstractJob(id, jobData, configuration) {
 
   /** @type {Number} */
   this._maxRunningTime = 24 * 60 * 60 * 1000;
+
+  /** @type {Number} */
+  this._retryCount = 0;
 }
 
 /**
@@ -139,7 +142,7 @@ AbstractJob.prototype._runJobScript = function(commandText) {
       return result.stdout.toString();
     })
     .catch(function(error) {
-      context.extend({exception: error});
+      context.extend({exception: error, retryCount: self._retryCount++});
       serviceLocator.get('logger').error('Failed job process', context);
       throw error;
     })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cm-janus",
   "description": "",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "",


### PR DESCRIPTION
For alerting it would be nice if we could include the number of retries a job was tried in the log entry "Failed job process".

@vogdb wdyt, can it be easily added?

cc @kris-lab @tomaszdurka 