### PR TITLE
Move "retryCount" away from root level

### DIFF
--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -142,7 +142,8 @@ AbstractJob.prototype._runJobScript = function(commandText) {
       return result.stdout.toString();
     })
     .catch(function(error) {
-      context.extend({exception: error, retryCount: self._retryCount++});
+      error.retryCount = self._retryCount++;
+      context.extend({exception: error});
       serviceLocator.get('logger').error('Failed job process', context);
       throw error;
     })


### PR DESCRIPTION
Added in: https://github.com/cargomedia/cm-janus/pull/264

I would suggest to move this field away from the root level of log entries. Compare [guidelines](https://github.com/cargomedia/guides/tree/master/logging).

I'm thinking either `jobData.retryCount` or `exception.retryCount`. I would go with the second.

@tomaszdurka @vogdb wdyt?