### PR TITLE
Remove all "subscribe" streams when a rtpbroadcast "publish" stream is removed

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -35,7 +35,7 @@ Channel.prototype.getContext = function() {
  * @returns {Boolean}
  */
 Channel.prototype.equalTo = function(channel) {
-  return channel && this.id == channel.id && this.name == channel.name;
+  return channel && this.id == channel.id;
 };
 
 /**

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -31,6 +31,14 @@ Channel.prototype.getContext = function() {
 };
 
 /**
+ * @param {Channel} channel
+ * @returns {Boolean}
+ */
+Channel.prototype.equalTo = function(channel) {
+  return channel && this.id == channel.id && this.name == channel.name;
+};
+
+/**
  * @param {String} name
  * @param {String} data
  * @returns {Channel}

--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -70,7 +70,7 @@ PluginVideo.prototype.removeStream = function() {
         promise = Promise.resolve();
       }
       if (plugin._isPublish) {
-        var subscribeStreams = serviceLocator.get('streams').findByChannel(plugin.stream.channel);
+        var subscribeStreams = serviceLocator.get('streams').findAllByChannel(plugin.stream.channel);
         subscribeStreams = _.without(subscribeStreams, plugin.stream);
         promise = Promise.map(subscribeStreams, function(subscribeStream) {
           return subscribeStream.plugin.removeStream();

--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -73,9 +73,9 @@ PluginVideo.prototype.removeStream = function() {
         var subscribeStreams = serviceLocator.get('streams').findByChannel(plugin.stream.channel);
         subscribeStreams = _.without(subscribeStreams, plugin.stream);
         promise = Promise.map(subscribeStreams, function(subscribeStream) {
-          return subscribeStream.plugin.removeStream().then(function() {
-            return serviceLocator.get('http-client').detach(subscribeStream.plugin);
-          });
+          return subscribeStream.plugin.removeStream();
+        }).then(function() {
+          plugin._isPublish = false;
         });
       }
       return promise.then(resolve, reject);

--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -62,17 +62,27 @@ PluginVideo.prototype.publish = function() {
  * @inheritDoc
  */
 PluginVideo.prototype.removeStream = function() {
-  if (this._isPublish) {
-    var subscribeStreams = serviceLocator.get('streams').findByChannel(this.getStream().channel);
-    subscribeStreams = _.without(subscribeStreams, this.getStream());
-    return Promise.map(subscribeStreams, function(subscribeStream) {
-      return serviceLocator.get('http-client').detach(subscribeStream.plugin);
-    }).then(function() {
-      return PluginVideo.super_.prototype.removeStream.apply(this, arguments);
-    }.bind(this));
-  } else {
-    return PluginVideo.super_.prototype.removeStream.apply(this, arguments);
-  }
+  var plugin = this;
+  return (new Promise(function(resolve, reject) {
+    plugin.queue.push(function() {
+      var promise;
+      if (!plugin.stream || !plugin._isPublish) {
+        promise = Promise.resolve();
+      }
+      if (plugin._isPublish) {
+        var subscribeStreams = serviceLocator.get('streams').findByChannel(plugin.stream.channel);
+        subscribeStreams = _.without(subscribeStreams, plugin.stream);
+        promise = Promise.map(subscribeStreams, function(subscribeStream) {
+          return subscribeStream.plugin.removeStream().then(function() {
+            return serviceLocator.get('http-client').detach(subscribeStream.plugin);
+          });
+        });
+      }
+      return promise.then(resolve, reject);
+    });
+  })).then(function() {
+    return PluginVideo.super_.prototype.removeStream.apply(plugin, arguments);
+  });
 };
 
 /**

--- a/lib/janus/plugin/video.js
+++ b/lib/janus/plugin/video.js
@@ -1,4 +1,5 @@
 var util = require('util');
+var _ = require('underscore');
 var Promise = require('bluebird');
 var PluginStreaming = require('./streaming');
 var Stream = require('../../stream');
@@ -7,6 +8,8 @@ var serviceLocator = require('../../service-locator');
 
 function PluginVideo(id, type, session) {
   PluginVideo.super_.apply(this, arguments);
+
+  this._isPublish = false;
 }
 
 util.inherits(PluginVideo, PluginStreaming);
@@ -42,6 +45,34 @@ PluginVideo.prototype.processMessage = function(message) {
   }
 
   return PluginVideo.super_.prototype.processMessage.call(this, message);
+};
+
+/**
+ * @inheritDoc
+ */
+PluginVideo.prototype.publish = function() {
+  return PluginVideo.super_.prototype.publish.call(this)
+    .then(function(result) {
+      this._isPublish = true;
+      return result;
+    }.bind(this));
+};
+
+/**
+ * @inheritDoc
+ */
+PluginVideo.prototype.removeStream = function() {
+  if (this._isPublish) {
+    var subscribeStreams = serviceLocator.get('streams').findByChannel(this.getStream().channel);
+    subscribeStreams = _.without(subscribeStreams, this.getStream());
+    return Promise.map(subscribeStreams, function(subscribeStream) {
+      return serviceLocator.get('http-client').detach(subscribeStream.plugin);
+    }).then(function() {
+      return PluginVideo.super_.prototype.removeStream.apply(this, arguments);
+    }.bind(this));
+  } else {
+    return PluginVideo.super_.prototype.removeStream.apply(this, arguments);
+  }
 };
 
 /**

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -65,7 +65,7 @@ Streams.prototype.find = function(streamId) {
  * @param {Channel} channel
  * @returns {Stream[]}
  */
-Streams.prototype.findByChannel = function(channel) {
+Streams.prototype.findAllByChannel = function(channel) {
   return _.filter(this.list, function(stream) {
     return channel.equalTo(stream.channel);
   });

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -62,6 +62,16 @@ Streams.prototype.find = function(streamId) {
 };
 
 /**
+ * @param {Channel} channel
+ * @returns {Stream[]}
+ */
+Streams.prototype.findByChannel = function(channel) {
+  return _.filter(this.list, function(stream) {
+    return channel.equalTo(stream.channel);
+  });
+};
+
+/**
  * @returns {Array.<Stream>}
  */
 Streams.prototype.getAll = function() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cm-janus",
   "description": "",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "",

--- a/test/helpers/globals.js
+++ b/test/helpers/globals.js
@@ -23,4 +23,5 @@ log4js.configure({
     }
   ]
 });
+serviceLocator.reset();
 serviceLocator.register('logger', new Logger(log4js.getLogger()));

--- a/test/spec/janus/plugin/video.js
+++ b/test/spec/janus/plugin/video.js
@@ -322,16 +322,7 @@ describe('Video plugin', function() {
   });
 
   context('removes streams with the same channel on removeStream', function() {
-    var stubHttpClient;
-
     before(function() {
-      stubHttpClient = {
-        detach: sinon.spy(function() {
-          return Promise.resolve();
-        })
-      };
-      serviceLocator.register('http-client', stubHttpClient);
-
       var stubCmApiClient = {
         removeStream: Promise.resolve,
         subscribe: Promise.resolve,
@@ -352,6 +343,7 @@ describe('Video plugin', function() {
       var stream1Publish = Stream.generate(new Channel('id1', 'name1', ''), plugin);
       var stream2 = Stream.generate(new Channel('id2', 'name2', ''), plugin);
       var subscribePlugin = new PluginVideo('', '', session);
+      sinon.stub(subscribePlugin, 'removeStream', Promise.resolve);
       var stream1Subscribe = Stream.generate(new Channel('id1', 'name1', ''), subscribePlugin);
       var streams = serviceLocator.get('streams');
       streams.addSubscribe(stream2);
@@ -366,8 +358,7 @@ describe('Video plugin', function() {
           return plugin.removeStream();
         })
         .then(function() {
-          assert.equal(stubHttpClient.detach.callCount, 1);
-          assert.isTrue(stubHttpClient.detach.withArgs(subscribePlugin).calledOnce);
+          assert.equal(subscribePlugin.removeStream.callCount, 1);
           done();
         });
     });

--- a/test/unit/streams.js
+++ b/test/unit/streams.js
@@ -2,6 +2,7 @@ var assert = require('chai').assert;
 var sinon = require('sinon');
 var _ = require('underscore');
 require('../helpers/globals');
+var Channel = require('../../lib/channel');
 var Stream = require('../../lib/stream');
 var Streams = require('../../lib/streams');
 var CmApiClient = require('../../lib/cm-api-client');
@@ -129,6 +130,20 @@ describe('streams', function() {
     streams.list[stream.id] = stream;
     assert.strictEqual(streams.find('foo'), stream);
     assert.strictEqual(streams.find('bar'), null);
+  });
+
+  it('findByChannel', function() {
+    var streams = new Streams();
+    var stream = sinon.createStubInstance(Stream);
+    var channel1 = new Channel('id1', 'name1', '');
+    var channel2 = new Channel('id2', 'name2', '');
+    var channel1copy = new Channel('id1', 'name1', 'hello');
+    stream.channel = channel1;
+    streams._add(stream);
+
+    assert.sameMembers(streams.findByChannel(channel1), [stream]);
+    assert.lengthOf(streams.findByChannel(channel2), 0);
+    assert.deepEqual(streams.findByChannel(channel1copy), [stream]);
   });
 
   it('_add', function() {

--- a/test/unit/streams.js
+++ b/test/unit/streams.js
@@ -132,7 +132,7 @@ describe('streams', function() {
     assert.strictEqual(streams.find('bar'), null);
   });
 
-  it('findByChannel', function() {
+  it('findAllByChannel', function() {
     var streams = new Streams();
     var stream = sinon.createStubInstance(Stream);
     var channel1 = new Channel('id1', 'name1', '');
@@ -141,9 +141,9 @@ describe('streams', function() {
     stream.channel = channel1;
     streams._add(stream);
 
-    assert.sameMembers(streams.findByChannel(channel1), [stream]);
-    assert.lengthOf(streams.findByChannel(channel2), 0);
-    assert.deepEqual(streams.findByChannel(channel1copy), [stream]);
+    assert.sameMembers(streams.findAllByChannel(channel1), [stream]);
+    assert.lengthOf(streams.findAllByChannel(channel2), 0);
+    assert.deepEqual(streams.findAllByChannel(channel1copy), [stream]);
   });
 
   it('_add', function() {


### PR DESCRIPTION
Goal: make sure that all "subscribes" are removed against CM's API *before* sending the "unpublish" call. This way we can avoid streamchannels with only subscribes that appear briefly after an unsubscribe.

Would it make sense to send "unsubscribe" for all subscribers in `PluginVideo.removeStream()`, if the publish stream is removed?
We could also remove the whole plugin then…

Note: the plugin is in a unusable state after unpublish anyway, because any attempts to republish will fail, because CM will find that this "mediaId" already existed.

@tomaszdurka @vogdb wdyt?