### PR TITLE
CM RPC API: remove site id

### DIFF
--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -8,7 +8,7 @@ janus:
   webSocketAddress: 'ws://198.23.87.26:8188/janus' # janus-gateway webSocket address
   httpAddress: 'http://198.23.87.26:8188/janus' # janus-gateway http address
 cmApi:
-  baseUrl: 'http://www.cm.dev/rpc/null' # cm-application address
+  baseUrl: 'http://www.cm.dev/rpc' # cm-application address
   apiKey: '123fish' # token for authentication, sent with each http request
 cmApplication:
   path: '/home/cm' # path to local cm application


### PR DESCRIPTION
After https://github.com/cargomedia/cm/pull/2213 the site ID is not anymore part of the RPC endpoint.
Can you remove it from the docu and configuration?

Old:
```
http://www.cm.dev/rpc/null
```

New:
```
http://www.cm.dev/rpc
```