### PR TITLE
AbstractJob context.janus is overwritten by child classes

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var deepExtend = require('util')._extend;
+var deepExtend = require('deep-extend');
 
 function Context(fields) {
   this.fields = _.clone(fields) || {};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bluebird": "~3.0.0",
     "body-parser": "^1.14.1",
     "child-process-promise": "^1.1.0",
+    "deep-extend": "vogdb/node-deep-extend",
     "express": "^4.13.3",
     "inotify": "^1.4.0",
     "is-plain-object": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cm-janus",
   "description": "",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "",


### PR DESCRIPTION
Reason:
![image](https://cloud.githubusercontent.com/assets/113303/16836397/a620cbc4-49bd-11e6-9aaf-a018e8bb93ee.png)


Seems that our `var deepExtend = require('util')._extend;` doesn't work as expected.
https://github.com/cargomedia/cm-janus/blob/master/lib/context.js#L2

Did experiment:
```
tomasz@panda:~$ node
> var deepExtend = require('util')._extend;
undefined
> var hash = {janus: {jobId: 1}};
undefined
> deepExtend(hash, {janus: {jobData: {foo: 'bar'}}});
{ janus: { jobData: { foo: 'bar' } } }
> console.log(hash);
{ janus: { jobData: { foo: 'bar' } } }
undefined
```

Maybe let's go back to `deepExtend` after all?