### PR TITLE
Do not send stdout/stderr on failedRepeatedly exceptions

### DIFF
--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -143,11 +143,11 @@ AbstractJob.prototype._runJobScript = function(commandText) {
     })
     .catch(function(error) {
       self._retryCount++;
-      if (self._retryCount > 10) {
+      if (self._retryCount % 10 == 0) {
         error.failedRepeatedly = true;
+        context.extend({exception: error});
+        serviceLocator.get('logger').error('Failed job process', context);
       }
-      context.extend({exception: error});
-      serviceLocator.get('logger').error('Failed job process', context);
       throw error;
     })
     .finally(function() {

--- a/lib/job/processor.js
+++ b/lib/job/processor.js
@@ -63,8 +63,8 @@ JobProcessor.prototype.process = function(job) {
  */
 JobProcessor.prototype.processUntilSuccessful = function(job) {
   var self = this;
-  return this.process(job).catch(function(error) {
-    serviceLocator.get('logger').warn('Job processing failed. Reattempt.', job.getContext().extend({exception: error}));
+  return this.process(job).catch(function() {
+    serviceLocator.get('logger').warn('Job processing failed. Reattempt.', job.getContext());
     return Promise.delay(self._retryDelay).then(function() {
       return self.processUntilSuccessful(job);
     })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cm-janus",
   "description": "",
-  "version": "0.8.17",
+  "version": "0.8.18",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "",


### PR DESCRIPTION
just to be sure, we log every time, but we add stdout/stdeer every Xth time? or we log nothing or everything every Xth time?

I would log nothing and everything every Xth time