### PR TITLE
Adjust command failure logging

### DIFF
--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -143,11 +143,13 @@ AbstractJob.prototype._runJobScript = function(commandText) {
     })
     .catch(function(error) {
       self._retryCount++;
-      if (self._retryCount % 10 == 0) {
+      if (self._retryCount > 10) {
         error.failedRepeatedly = true;
-        context.extend({exception: error});
-        serviceLocator.get('logger').error('Failed job process', context);
       }
+      if (self._retryCount < 20) {
+        context.extend({exception: error});
+      }
+      serviceLocator.get('logger').error('Failed job process', context);
       throw error;
     })
     .finally(function() {

--- a/lib/job/model/abstract.js
+++ b/lib/job/model/abstract.js
@@ -146,9 +146,11 @@ AbstractJob.prototype._runJobScript = function(commandText) {
       if (self._retryCount > 10) {
         error.failedRepeatedly = true;
       }
-      if (self._retryCount < 20) {
-        context.extend({exception: error});
+      if (self._retryCount > 20) {
+        error.stderr = null;
+        error.stdout = null;
       }
+      context.extend({exception: error});
       serviceLocator.get('logger').error('Failed job process', context);
       throw error;
     })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cm-janus",
   "description": "",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "",


### PR DESCRIPTION
As discussed with Tomasz:
- Log all incidents as errors
- Add `failedRepeatedly` at/after 10th incident
- Remove command output at/after 20th incident