### PR TITLE
Not detected "job" files when moved to the folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure('2') do |config|
   config.ssh.forward_agent = true
-  config.vm.box = 'cargomedia/debian-7-amd64-default'
+  config.vm.box = 'cargomedia/debian-8-amd64-default'
 
   config.vm.hostname = 'cm-janus.dev.cargomedia.ch'
 

--- a/lib/job/file-listener.js
+++ b/lib/job/file-listener.js
@@ -30,7 +30,7 @@ FileListener.prototype.stop = function() {
 FileListener.prototype._listenForNewFiles = function() {
   this._watch = this._inotify.addWatch({
     path: this._jobsDirectory,
-    watch_for: Inotify.IN_CLOSE_WRITE,
+    watch_for: Inotify.IN_CLOSE_WRITE | Inotify.IN_MOVED_TO,
     callback: function(event) {
       if (event.name) {
         var filePath = path.join(this._jobsDirectory, event.name);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cm-janus",
   "description": "",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "",

--- a/test/spec/job/file-listener.js
+++ b/test/spec/job/file-listener.js
@@ -10,6 +10,7 @@ var FileListener = require('../../../lib/job/file-listener');
 describe('FileListener', function() {
 
   var tmpDirPath = path.join(__dirname, '/tmp');
+  var tmp1DirPath = path.join(__dirname, '/tmp1');
 
   function randomString() {
     return Math.random().toString(36).substring(2, 10);
@@ -21,12 +22,18 @@ describe('FileListener', function() {
     return filepath;
   }
 
+  function moveFile(srcpath, destpath) {
+    fs.rename(srcpath, destpath);
+  }
+
   beforeEach(function() {
     mkdirp.sync(tmpDirPath);
+    mkdirp.sync(tmp1DirPath);
   });
 
   afterEach(function() {
     rimraf.sync(tmpDirPath);
+    rimraf.sync(tmp1DirPath);
   });
 
   it('emits events for existing files', function(done) {
@@ -59,6 +66,22 @@ describe('FileListener', function() {
     });
 
     newfilePath = createTmpFile(tmpDirPath, {});
+  });
+
+  it('emits event for a file moved into directory', function(done) {
+    var tmpfilePath;
+    var newfilePath = path.join(tmpDirPath, randomString() + '.json');
+    var fileListener = new FileListener(tmpDirPath);
+    fileListener.start();
+
+    fileListener.on('file', function(filepath) {
+      assert.equal(newfilePath, filepath);
+      fileListener.stop();
+      done();
+    });
+
+    tmpfilePath = createTmpFile(tmp1DirPath, {});
+    moveFile(tmpfilePath, newfilePath);
   });
 
 });


### PR DESCRIPTION
Until plugin version `0.0.28` of https://github.com/cargomedia/janus-gateway-rtpbroadcast the JobFile was created within final jobs folder (e.g. `/tmp/jobs`). `cm-janus` was listening for changes and pick-up new coming jobs/files.

Since plugin `0.0.29-beta` the job files are not created directly into final job folder (subscribed by cm-janus), but rather created in temporary job folder (e.g. `/tmp/jobs-temp`) and moved to final job folder (e.g. `/tmp/jobs`) after the task is finished.

This was introduced beacuse of https://github.com/cargomedia/janus-gateway-rtpbroadcast/pull/107

@tomaszdurka wdyt?
cc @njam